### PR TITLE
Tweak of messaging for tracking promotions

### DIFF
--- a/frontend/src/directives/PromotionType.es6
+++ b/frontend/src/directives/PromotionType.es6
@@ -4,7 +4,8 @@ import types from "text!templates/PromotionType.html"
 export default () => {
     return {
         scope: {
-            promotion: '='
+            promotion: '=',
+            product: '='
         },
         restrict: 'E',
         template: types,

--- a/frontend/src/templates/PromotionForm.html
+++ b/frontend/src/templates/PromotionForm.html
@@ -16,7 +16,7 @@
                     <label>Description (for checkout page when promotion applied)</label><textarea ng-model="promotion.description" name="description" ng-trim="false" rows="3" required></textarea>
                 </md-input-container>
 
-                <promotion-type promotion="promotion"></promotion-type>
+                <promotion-type promotion="promotion" product="environment.product"></promotion-type>
                 <rate-plan-list product-rate-plan-ids="promotion.appliesTo.productRatePlanIds" product="environment.product"></rate-plan-list>
                 <available-countries countries="promotion.appliesTo.countries"></available-countries>
                 <promotion-dates promotion="promotion"></promotion-dates>

--- a/frontend/src/templates/PromotionType.html
+++ b/frontend/src/templates/PromotionType.html
@@ -42,7 +42,9 @@
 
         <!-- Tracking -->
         <md-tab label="Tracking" ng-click="ctrl.setPromotionType('tracking')">
-            <md-content class="md-padding md-tab-content"></md-content>
+            <md-content class="md-padding md-tab-content">
+                <p ng-show="product == 'membership'">For Tracking promotions, the <b>Rate plans</b> below are only used to choose the landing page tier.</p>
+            </md-content>
         </md-tab>
     </md-tabs>
 </div>


### PR DESCRIPTION
Put a message in the Promotion Type section (when on Membership view) which explains how the Rate plans are only used to determine the landing page tier, and won't affect the tracking promotion's eligibility.

cc @tomverran @nlindblad 