### PR TITLE
Disallow same type of promo twice

### DIFF
--- a/frontend/src/services/PromotionService.es6
+++ b/frontend/src/services/PromotionService.es6
@@ -38,6 +38,9 @@ export default class {
     }
 
     validate(promotion) {
+        if (promotion.promotionType.a.name == promotion.promotionType.b.name) {
+            return this.$q.reject(["Both promotions cannot be of the same type."])
+        }
         return this.$http({
             method: 'POST',
             url: '/promotion/validate',


### PR DESCRIPTION
The UI treats it as a back-end validation error, but we can think about changing that if we add more client side validation in the future.

![screen shot 2016-09-05 at 17 00 42](https://cloud.githubusercontent.com/assets/164991/18253156/5280402a-738a-11e6-997d-fb1c22b575bb.png)
