### PR TITLE
New views for Newspaper and Guardian Weekly

### DIFF
--- a/app/conf/PaperPlans.scala
+++ b/app/conf/PaperPlans.scala
@@ -9,6 +9,7 @@ case class PaperProducts(
 )
 
 case class PaperPlans(
+  sundayplus: ProductRatePlanId,
   weekend: ProductRatePlanId,
   weekendplus: ProductRatePlanId,
   sixday: ProductRatePlanId,
@@ -20,6 +21,7 @@ case class PaperPlans(
 object PaperProducts {
 
   def plansFor(config: Config, product: String) = PaperPlans(
+    sundayplus = ProductRatePlanId(config.getString(s"$product.sundayplus")),
     weekend = ProductRatePlanId(config.getString(s"$product.weekend")),
     weekendplus = ProductRatePlanId(config.getString(s"$product.weekendplus")),
     sixday = ProductRatePlanId(config.getString(s"$product.sixday")),

--- a/app/controllers/CampaignController.scala
+++ b/app/controllers/CampaignController.scala
@@ -1,25 +1,24 @@
 package controllers
 
 import actions.GoogleAuthAction.GoogleAuthenticatedAction
-import com.gu.memsub.ProductFamily
-import com.gu.memsub.promo.{Campaign, CampaignCode}
-import play.api.libs.concurrent.Execution.Implicits._
 import com.gu.memsub.promo.Formatters.CampaignFormatters._
-import com.gu.memsub.promo.Formatters.Common._
+import com.gu.memsub.promo.{Campaign, CampaignCode, CampaignGroup}
 import com.gu.memsub.services.JsonDynamoService
+import play.api.libs.concurrent.Execution.Implicits._
 import play.api.libs.json.{JsError, Json}
 import play.api.mvc.Result
-
-import scala.concurrent.Future
 import play.api.mvc.Results._
 import wiring.AppComponents.Stage
 
+import scala.concurrent.Future
+
 class CampaignController(googleAuthAction: GoogleAuthenticatedAction, service: JsonDynamoService[Campaign, Future], stage: Stage) {
 
-
-  def all(productFamily: Option[String]) = googleAuthAction.async {
-    val campaigns = productFamily.flatMap(ProductFamily.fromId).fold(service.all)(service.find)
-    campaigns.map(campaigns => Ok(Json.toJson(campaigns.sortBy(_.name))))
+  def all(group: Option[String]) = googleAuthAction.async {
+    service.all.map(campaigns => {
+      val filtered = group.flatMap(CampaignGroup.fromId).fold(campaigns)(group => campaigns.filter(_.group == group))
+      Ok(Json.toJson(filtered.sortBy(_.name)))
+    })
   }
 
   def get(code: Option[String]) = googleAuthAction.async {

--- a/app/controllers/RatePlanController.scala
+++ b/app/controllers/RatePlanController.scala
@@ -1,8 +1,8 @@
 package controllers
 import actions.GoogleAuthAction.GoogleAuthenticatedAction
 import com.gu.config.{DigitalPackRatePlanIds, MembershipRatePlanIds}
+import com.gu.memsub.promo.CampaignGroup.{Membership, DigitalPack, Newspaper, GuardianWeekly}
 import com.gu.memsub.Subscription.ProductRatePlanId
-import com.gu.memsub.{Digipack, Membership}
 import conf.PaperProducts
 import play.api.libs.json._
 import play.api.mvc.Results._
@@ -28,23 +28,29 @@ class RatePlanController(
         membershipIds.patronMonthly -> "Patron monthly",
         membershipIds.patronYearly -> "Patron yearly"
       ).map(tupleToRatePlanMap)),
-      "digitalpack" -> Json.toJson(Seq(
+      DigitalPack.id -> Json.toJson(Seq(
         digipackIds.digitalPackMonthly -> "Digital pack monthly",
         digipackIds.digitalPackQuaterly -> "Digital pack quarterly",
-        digipackIds.digitalPackYearly -> "Digital pack yearly",
-        paperPlans.delivery.weekend -> "Paper delivery weekend",
-        paperPlans.delivery.weekendplus -> "Paper delivery weekend+",
-        paperPlans.delivery.sixday -> "Paper delivery sixday",
-        paperPlans.delivery.sixdayplus -> "Paper delivery sixday+",
-        paperPlans.delivery.everyday -> "Paper delivery everyday",
-        paperPlans.delivery.everydayplus -> "Paper delivery everyday+",
-        paperPlans.voucher.weekend -> "Paper voucher weekend",
-        paperPlans.voucher.weekendplus -> "Paper voucher weekend+",
-        paperPlans.voucher.sixday -> "Paper voucher sixday",
-        paperPlans.voucher.sixdayplus -> "Paper voucher sixday+",
-        paperPlans.voucher.everyday -> "Paper voucher everyday",
-        paperPlans.voucher.everydayplus -> "Paper voucher everyday+"
-      ).map(tupleToRatePlanMap))
+        digipackIds.digitalPackYearly -> "Digital pack yearly"
+      ).map(tupleToRatePlanMap)),
+      Newspaper.id -> Json.toJson(Seq(
+        paperPlans.delivery.sundayplus -> "Home Delivery Sunday+",
+        paperPlans.delivery.weekend -> "Home Delivery Weekend",
+        paperPlans.delivery.weekendplus -> "Home Delivery Weekend+",
+        paperPlans.delivery.sixday -> "Home Delivery Sixday",
+        paperPlans.delivery.sixdayplus -> "Home Delivery Sixday+",
+        paperPlans.delivery.everyday -> "Home Delivery Everyday",
+        paperPlans.delivery.everydayplus -> "Home Delivery Everyday+",
+        paperPlans.voucher.sundayplus -> "Voucher Sunday+",
+        paperPlans.voucher.weekend -> "Voucher Weekend",
+        paperPlans.voucher.weekendplus -> "Voucher Weekend+",
+        paperPlans.voucher.sixday -> "Voucher Sixday",
+        paperPlans.voucher.sixdayplus -> "Voucher Sixday+",
+        paperPlans.voucher.everyday -> "Voucher Everyday",
+        paperPlans.voucher.everydayplus -> "Voucher Everyday+"
+      ).map(tupleToRatePlanMap)),
+      // TODO - Guardian Weekly - Quarterly, Annual, International Quarterly, International Annual
+      GuardianWeekly.id -> Json.toJson(Seq().map(tupleToRatePlanMap))
     ))
   }
 }

--- a/app/views/main.scala.html
+++ b/app/views/main.scala.html
@@ -17,11 +17,11 @@
         <script src="@routes.Assets.versioned("javascripts/main.js")" type="text/javascript"></script>
     </head>
     <body ng-app="Promotions" layout="column">
-      <md-toolbar ng-class="environment.product">
+      <md-toolbar ng-class="[environment.campaignGroup, environment.stage.toLowerCase()]">
         <div class="md-toolbar-tools">
           <span environment-menu></span>
           <h2 class="md-clickable">
-            <span ui-sref="allPromotions.chooseCampaign">{{environment.product}} Promotions ({{environment.stage}})</span>
+            <span ui-sref="allPromotions.chooseCampaign">Guardian {{environment.campaignGroup}} Promotions ({{environment.stage}})</span>
           </h2>
           <span flex></span>
         </div>

--- a/app/wiring/AppLoader.scala
+++ b/app/wiring/AppLoader.scala
@@ -1,12 +1,10 @@
 package wiring
 
+import play.api.ApplicationLoader.Context
+import play.api.libs.ws.ahc.AhcWSComponents
 import play.api.mvc.Cookies
 import play.api.routing.Router
-import play.api.ApplicationLoader.Context
-import play.api.{ApplicationLoader, BuiltInComponentsFromContext, Logger}
-import play.api._
-import play.api.libs.ws.ahc.AhcWSComponents
-import play.api.libs.ws.ning.NingWSComponents
+import play.api.{ApplicationLoader, BuiltInComponentsFromContext, _}
 
 
 class AppLoader extends ApplicationLoader {
@@ -25,8 +23,10 @@ class AppLoader extends ApplicationLoader {
         "DEV" -> new AppComponents(AppComponents.DEV, this).router
       )
 
+      lazy val defaultRouter = map("PROD")
+
       lazy val router: Router = new MultiRouter((c: Cookies) =>
-        c.find(_.name == "stage").map(_.value.toUpperCase).flatMap(map.get).getOrElse(map("DEV")), map("DEV"))
+        c.find(_.name == "stage").map(_.value.toUpperCase).flatMap(map.get).getOrElse(defaultRouter), defaultRouter)
     }.application
   }
 }

--- a/build.sbt
+++ b/build.sbt
@@ -29,7 +29,7 @@ libraryDependencies ++= Seq(
   cache,
   ws,
   "org.scalaz" %% "scalaz-core" % "7.1.3",
-  "com.gu" %% "membership-common" % "0.265",
+  "com.gu" %% "membership-common" % "0.275",
   "com.gu" %% "memsub-common-play-auth" % "0.7",
   "com.softwaremill.macwire" %% "macros" % "2.2.2" % "provided",
   "com.softwaremill.macwire" %% "util" % "2.2.2",

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -16,10 +16,11 @@ touchpoint.backend.environments {
     voucher {
       everydayplus=""
       everyday="2c92c0f9555cf10501556e84a70440e2"
-      sixdayplus=""
+      sixdayplus="2c92c0f855c3b8190155c585a95e6f5a"
       sixday="2c92c0f8555ce5cf01556e7f01771b8a"
       weekendplus=""
       weekend="2c92c0f8555ce5cf01556e7f01b81b94"
+      sundayplus="2c92c0f955a0b5bf0155b62623846fc8"
     }
     delivery {
       everydayplus=""
@@ -28,6 +29,7 @@ touchpoint.backend.environments {
       sixday="2c92c0f955c3cf0f0155c5d9ddf13bc5"
       weekendplus=""
       weekend="2c92c0f955c3cf0f0155c5d9df433bf7"
+      sundayplus="2c92c0f955c3cf0f0155c5d9e83a3cb7"
     }
   }
   UAT {
@@ -38,14 +40,16 @@ touchpoint.backend.environments {
       sixday="2c92c0f955ca02910155da254a641fb3"
       weekendplus="2c92c0f855c9f4b20155d9f1dd0651ab"
       weekend="2c92c0f855c9f4b20155d9f1db9b5199"
+      sundayplus="2c92c0f855c9f4b20155d9f1cc69508a"
     }
     delivery {
       everydayplus="2c92c0f955ca02900155da2803b02e33"
       everyday="2c92c0f955ca02900155da27f55b2d5f"
-      sixdayplus="2c92c0f955ca02900155da27f4872d4d"
+      sixdayplus="2c92c0f955ca02900155da27f29e2d13"
       sixday="2c92c0f955ca02900155da27ff142e01"
       weekendplus="2c92c0f955ca02900155da27f9402dad"
       weekend="2c92c0f955ca02900155da27f83c2d9b"
+      sundayplus="2c92c0f955ca02900155da27f4872d4d"
     }
   }
   PROD {
@@ -56,6 +60,7 @@ touchpoint.backend.environments {
       sixday="2c92a0fd56fe270b0157040e42e536ef"
       weekendplus="2c92a0fd56fe26b60157040cdd323f76"
       weekend="2c92a0ff56fe33f00157040f9a537f4b"
+      sundayplus="2c92a0fe56fe33ff0157040d4b824168"
     }
     delivery {
       everydayplus="2c92a0fd560d132301560e43cf041a3c"
@@ -64,6 +69,7 @@ touchpoint.backend.environments {
       sixday="2c92a0ff560d311b0156136f2afe5315"
       weekendplus="2c92a0ff560d311b0156136b9f5c3968"
       weekend="2c92a0fd5614305c01561dc88f3275be"
+      sundayplus="2c92a0fd560d13880156136b8e490f8b"
     }
   }
 }

--- a/conf/routes
+++ b/conf/routes
@@ -9,7 +9,7 @@ GET     /promotion                  controllers.PromotionController.get(uuid: Op
 POST    /promotion                  controllers.PromotionController.upsert
 POST    /promotion/validate         controllers.PromotionController.validate
 
-GET     /campaigns                  controllers.CampaignController.all(productFamily: Option[String])
+GET     /campaigns                  controllers.CampaignController.all(group: Option[String])
 GET     /campaign                   controllers.CampaignController.get(code: Option[String])
 POST    /campaign                   controllers.CampaignController.upsert
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -6,8 +6,10 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "js": "./node_modules/webpack/bin/webpack.js -d --optimize-minimize --optimize-dedup --config Webpack.js --display-error-details --bail",
+    "js-dev": "./node_modules/webpack/bin/webpack.js --config Webpack.js --display-error-details --bail",
     "sass": "./node_modules/node-sass/bin/node-sass sass/main.sass ../public/stylesheets/main.css",
-    "compile": "npm run js && npm run sass"
+    "compile": "npm run js && npm run sass",
+    "dev": "npm run js-dev && npm run sass"
   },
   "devDependencies": {
     "angular": "^1.5.5",

--- a/frontend/sass/main.sass
+++ b/frontend/sass/main.sass
@@ -42,13 +42,14 @@ md-tabs
   cursor: pointer
 
 md-toolbar
+  background-color: #00456e
   cursor: pointer
   transition: background-color 0.5s
   transition-delay: 0.2s
   text-transform: capitalize
 
-md-toolbar.digitalpack
-  background-color: #00456e
+md-toolbar.uat
+  background-color: #d61d00
 
 md-toolbar.membership
   background-color: rgb(187, 58, 127)
@@ -65,7 +66,7 @@ md-icon > a
 
 .landing-page-image
   background-color: #EEEEEE
-  background-position: middle middle;
+  background-position: center
   border: 1px solid #ccc
   background-size: cover
   margin-bottom: 20px

--- a/frontend/src/controllers/ChannelCodesController.es6
+++ b/frontend/src/controllers/ChannelCodesController.es6
@@ -4,11 +4,11 @@ export default class {
     constructor($scope, environmentService) {
         this.$scope = $scope;
         this.environmentService = environmentService;
-        this.$scope.productDomain = this.environmentService.getProductDomain();
+        this.$scope.campaignGroupDomain = this.environmentService.getCampaignGroupDomain();
     }
 
     generateSuggestedPromoCode() {
-        return this.environmentService.getProductPrefix() + new Date().getTime().toString(36).toUpperCase();
+        return this.environmentService.getCampaignGroupPrefix() + new Date().getTime().toString(36).toUpperCase();
     }
 
     addChannel(newChannelName) {

--- a/frontend/src/controllers/EditCampaignController.es6
+++ b/frontend/src/controllers/EditCampaignController.es6
@@ -15,7 +15,8 @@ export default class {
 
     fetchCampaign(code) {
         if (!code) {
-            this.$scope.campaign = { name: "", code: this.generateSuggestedCampaignCode(), productFamily: this.environmentService.getProduct()} ;
+            this.$scope.campaign = {
+                name: "", code: this.generateSuggestedCampaignCode(), group: this.environmentService.getCampaignGroup()} ;
             return;
         }
         this.campaignService.get(code).then(r => {

--- a/frontend/src/controllers/EnvironmentController.es6
+++ b/frontend/src/controllers/EnvironmentController.es6
@@ -1,12 +1,9 @@
-const PRODUCT = 'product';
-const STAGE = 'stage';
-
 export default class {
 
     /* @ngInject */
     constructor($state, $rootScope, $scope, environmentService) {
         this.$state = $state;
-        $rootScope.environment = {stage: environmentService.getStage(), product: environmentService.getProduct()};
+        $rootScope.environment = {stage: environmentService.getStage(), campaignGroup: environmentService.getCampaignGroup()};
         this.environmentService = environmentService;
         this.$scope = $scope;
     }
@@ -17,9 +14,9 @@ export default class {
         this.$state.go('allPromotions.chooseCampaign', {}, {reload: true});
     }
     
-    setProductFamily(pf) {
-        this.$scope.environment.product = pf;
-        this.environmentService.setProduct(pf);
+    setCampaignGroup(campaignGroup) {
+        this.environmentService.setCampaignGroup(campaignGroup);
+        this.$scope.environment.campaignGroup = campaignGroup;
         this.$state.go('allPromotions.chooseCampaign', {}, {reload: true});
     }
 }

--- a/frontend/src/controllers/GridImageSelectorController.es6
+++ b/frontend/src/controllers/GridImageSelectorController.es6
@@ -5,7 +5,7 @@ export default class {
         this.gridOrigin = 'https://' + environmentService.getGridUrl();
         $scope.gridUrl = this.gridOrigin;
 
-        $scope.product = environmentService.getProduct();
+        $scope.campaignGroup = environmentService.getCampaignGroup();
         this.environmentService = environmentService;
         this.$scope = $scope;
     }

--- a/frontend/src/controllers/LandingPageController.es6
+++ b/frontend/src/controllers/LandingPageController.es6
@@ -5,11 +5,11 @@ export default class {
         this.environmentService = environmentService;
         this.$scope = $scope;
         this.$scope.backup = this.blankBackup();
-        this.$scope[this.environmentService.getProduct()] = true;
+        this.$scope[this.environmentService.getCampaignGroup()] = true;
     }
 
     blankBackup() {
-        return {productFamily: this.environmentService.getProduct()}
+        return { type: this.environmentService.getCampaignGroup() }
     }
 
     toggleBackup(promo, backup) {

--- a/frontend/src/controllers/PreviewPromotionController.es6
+++ b/frontend/src/controllers/PreviewPromotionController.es6
@@ -8,7 +8,7 @@ export default class {
         $scope.mode = 'desktop';
         this.$scope = $scope;
         
-        this.$scope.src = 'https://' + this.environmentService.getProductDomain() + '/q';
+        this.$scope.src = 'https://' + this.environmentService.getCampaignGroupDomain() + '/q';
         
     }
 

--- a/frontend/src/controllers/PromotionFormController.es6
+++ b/frontend/src/controllers/PromotionFormController.es6
@@ -21,7 +21,7 @@ export default class {
         this.$q = $q;
 
         this.$scope.serverErrors = [];
-        this.$scope.productDomain = this.environmentService.getProductDomain();
+        this.$scope.campaignGroupDomain = this.environmentService.getCampaignGroupDomain();
 
         if ($stateParams.uuid) {
             this.fetchPromotion($stateParams.uuid);
@@ -35,7 +35,7 @@ export default class {
     createNewPromotion(campaignCode) {
         this.$scope.promotion = Object.assign({}, emptyPromotion, 
             {campaignCode: campaignCode, uuid: this.uuid.v4()},
-            {landingPage: {productFamily: this.environmentService.getProduct()}});
+            {landingPage: {type: this.environmentService.getCampaignGroup()}});
         return this.fillCampaignInfo(this.$scope.promotion)
     }
 

--- a/frontend/src/controllers/PromotionListController.es6
+++ b/frontend/src/controllers/PromotionListController.es6
@@ -8,7 +8,7 @@ export default class {
         this.$scope = $scope;
         this.fetchPromotions($stateParams.code);
         this.$scope.code = $stateParams.code;
-        this.$scope.productDomain = this.environmentService.getProductDomain();
+        this.$scope.campaignGroupDomain = this.environmentService.getCampaignGroupDomain();
     }
 
     fetchPromotions(code) {

--- a/frontend/src/controllers/RatePlanListController.es6
+++ b/frontend/src/controllers/RatePlanListController.es6
@@ -16,7 +16,7 @@ export default class {
     }
 
     populateRatePlans(productRatePlanIds) {
-        this.$scope.ratePlanIds = this.arrayToMap(productRatePlanIds)
+        this.$scope.ratePlanIds = this.arrayToMap(productRatePlanIds);
     }
 
     applyRatePlans(ratePlanIds) {

--- a/frontend/src/directives/Modal.es6
+++ b/frontend/src/directives/Modal.es6
@@ -7,7 +7,7 @@ export default () => {
         scope: {
             show: '=',
             title: '@title',
-            product: '='
+            campaignGroup: '='
         },
         restrict: 'E',
         template: template,

--- a/frontend/src/directives/MultiPromotionType.es6
+++ b/frontend/src/directives/MultiPromotionType.es6
@@ -5,7 +5,7 @@ export default () => {
     return {
         scope: {
             promotion: '=',
-            product: '='
+            campaignGroup: '='
         },
         restrict: 'E',
         template: types,

--- a/frontend/src/directives/PromotionType.es6
+++ b/frontend/src/directives/PromotionType.es6
@@ -5,7 +5,7 @@ export default () => {
     return {
         scope: {
             promotionType: '=',
-            product: '='
+            campaignGroup: '='
         },
         restrict: 'E',
         template: types,

--- a/frontend/src/directives/RatePlanList.es6
+++ b/frontend/src/directives/RatePlanList.es6
@@ -5,7 +5,7 @@ export default () => {
     return {
         scope: {
             'productRatePlanIds': '=',
-            'product': '='
+            'campaignGroup': '='
         },
         restrict: 'E',
         template: template,

--- a/frontend/src/services/CampaignService.es6
+++ b/frontend/src/services/CampaignService.es6
@@ -10,7 +10,7 @@ export default class {
         return this.$http({
             method: 'GET',
             url: '/campaigns',
-            params: {productFamily: this.env.getProduct()}
+            params: {'group': this.env.getCampaignGroup()}
         }).then(response => response.data)
     }
 
@@ -18,11 +18,17 @@ export default class {
         return this.$http({
             method: 'GET',
             url: '/campaign',
-            params: {code: code}
+            params: {'code': code}
         }).then(response => response.data)
     }
 
     save(campaign) {
+
+        // Backwards compatibility of legacy serialisations where group was identified by product_family.
+        // Deleting product_family tidies up old field upon saving
+        campaign.group = campaign.group || campaign.product_family;
+        delete campaign.product_family;
+
         return this.$http({
             method: 'POST',
             url: '/campaign',

--- a/frontend/src/services/CampaignService.es6
+++ b/frontend/src/services/CampaignService.es6
@@ -26,8 +26,8 @@ export default class {
 
         // Backwards compatibility of legacy serialisations where group was identified by product_family.
         // Deleting product_family tidies up old field upon saving
-        campaign.group = campaign.group || campaign.product_family;
-        delete campaign.product_family;
+        campaign.group = campaign.group || campaign.productFamily;
+        delete campaign.productFamily;
 
         return this.$http({
             method: 'POST',

--- a/frontend/src/services/CampaignService.es6
+++ b/frontend/src/services/CampaignService.es6
@@ -24,8 +24,8 @@ export default class {
 
     save(campaign) {
 
-        // Backwards compatibility of legacy serialisations where group was identified by product_family.
-        // Deleting product_family tidies up old field upon saving
+        // Backwards compatibility of legacy serialisations where group was identified by productFamily.
+        // Deleting productFamily tidies up old field upon saving
         campaign.group = campaign.group || campaign.productFamily;
         delete campaign.productFamily;
 

--- a/frontend/src/services/EnvironmentService.es6
+++ b/frontend/src/services/EnvironmentService.es6
@@ -1,19 +1,27 @@
-const PRODUCT = 'product';
+const CAMPAIGN_GROUP = 'campaign_group';
+const DEFAULT_CAMPAIGN_GROUP = 'digitalpack';
 const STAGE = 'stage';
+const DEFAULT_STAGE = 'PROD';   // Must match the default router in AppLoader.scala
 const PRODUCT_DOMAINS = {
     'DEV': {
         'membership': 'mem.thegulocal.com',
         'digitalpack': 'sub.thegulocal.com',
+        'newspaper': 'sub.thegulocal.com',
+        'weekly': 'sub.thegulocal.com',
         'grid': 'media.gutools.co.uk'
     },
     'PROD': {
         'membership': 'membership.theguardian.com',
         'digitalpack': 'subscribe.theguardian.com',
+        'newspaper': 'subscribe.theguardian.com',
+        'weekly': 'subscribe.theguardian.com',
         'grid': 'media.gutools.co.uk'
     },
     'UAT': {
         'membership': 'membership.theguardian.com',
         'digitalpack': 'subscribe.theguardian.com',
+        'newspaper': 'subscribe.theguardian.com',
+        'weekly': 'subscribe.theguardian.com',
         'grid': 'media.gutools.co.uk'
     }
 };
@@ -34,18 +42,20 @@ export default class {
         this.$cookies.put(STAGE, newStage)
     }
 
-    setProduct(newProduct) {
-        this.$cookies.put(PRODUCT, newProduct)
+    setCampaignGroup(campaignGroup) {
+        this.$cookies.put(CAMPAIGN_GROUP, campaignGroup)
     }
     
-    getProduct() {
-        return getOrDefault(this.$cookies, PRODUCT, 'digitalpack')
+    getCampaignGroup() {
+        return getOrDefault(this.$cookies, CAMPAIGN_GROUP, DEFAULT_CAMPAIGN_GROUP)
     }
 
-    getProductPrefix() {
-        switch (this.getProduct()) {
+    getCampaignGroupPrefix() {
+        switch (this.getCampaignGroup()) {
             case 'membership': return 'M';
             case 'digitalpack': return 'D';
+            case 'newspaper': return 'N';
+            case 'weekly': return 'W';
         }
         return ''
     }
@@ -54,11 +64,11 @@ export default class {
         return PRODUCT_DOMAINS[this.getStage()]['grid'] || '';
     }
 
-    getProductDomain() {
-        return PRODUCT_DOMAINS[this.getStage()][this.getProduct()] || '';
+    getCampaignGroupDomain() {
+        return PRODUCT_DOMAINS[this.getStage()][this.getCampaignGroup()] || '';
     }
 
     getStage() {
-        return getOrDefault(this.$cookies, STAGE, 'PROD')
+        return getOrDefault(this.$cookies, STAGE, DEFAULT_STAGE)
     }
 }

--- a/frontend/src/templates/CampaignList.html
+++ b/frontend/src/templates/CampaignList.html
@@ -10,7 +10,7 @@
                 <div class="md-list-item-text" layout="column">
                     <div ui-sref="allPromotions.singleCampaign({code: campaign.code})">
                         <h3>{{ campaign.name }}</h3>
-                        <h4>{{ campaign.code }}</h4>
+                        <p>{{ campaign.code }}</p>
                     </div>
                     <md-icon class="md-secondary" md-font-set="material-icons" ui-sref="editCampaign({code: campaign.code})">mode_edit</md-icon>
                 </div>

--- a/frontend/src/templates/ChannelCodes.html
+++ b/frontend/src/templates/ChannelCodes.html
@@ -18,7 +18,7 @@
                 </ng-form>
                 <div>
                     <md-input-container ng-repeat="code in channel.codes track by $index" class="code-container">
-                        <md-icon md-font-set="material-icons" md-menu-align-target><a target="_blank" href="https://{{ productDomain }}/p/{{ channel.codes[$index] }}">open_in_browser</a></md-icon>
+                        <md-icon md-font-set="material-icons" md-menu-align-target><a target="_blank" href="https://{{ campaignGroupDomain }}/p/{{ channel.codes[$index] }}">open_in_browser</a></md-icon>
                         <label for="code">Promo Code</label>
                         <input type="text" id="code" ng-model="channel.codes[$index]" ng-change="ctrl.codeUpdated(channels, channel.name, channel.codes[$index])">
                     </md-input-container>

--- a/frontend/src/templates/EnvironmentMenu.html
+++ b/frontend/src/templates/EnvironmentMenu.html
@@ -4,34 +4,46 @@
     </md-button>
     <md-menu-content width="4">
         <md-menu-item>
-            <md-button ng-click="ctrl.setProductFamily('membership')">
-                <md-icon md-font-set="material-icons" md-menu-align-target>shopping_cart</md-icon>
+            <md-button ng-click="ctrl.setCampaignGroup('membership')">
+                <md-icon md-font-set="material-icons" md-menu-align-target>people</md-icon>
                 Membership
             </md-button>
         </md-menu-item>
         <md-menu-item>
-            <md-button ng-click="ctrl.setProductFamily('digitalpack')">
-                <md-icon md-font-set="material-icons" md-menu-align-target>shopping_cart</md-icon>
-                Subscriptions
+            <md-button ng-click="ctrl.setCampaignGroup('digitalpack')">
+                <md-icon md-font-set="material-icons" md-menu-align-target>tablet_mac</md-icon>
+                Digital Pack
+            </md-button>
+        </md-menu-item>
+        <md-menu-item>
+            <md-button ng-click="ctrl.setCampaignGroup('newspaper')">
+                <md-icon md-font-set="material-icons" md-menu-align-target>description</md-icon>
+                Newspaper
+            </md-button>
+        </md-menu-item>
+        <md-menu-item>
+            <md-button ng-click="ctrl.setCampaignGroup('weekly')">
+                <md-icon md-font-set="material-icons" md-menu-align-target>today</md-icon>
+                Guardian Weekly
             </md-button>
         </md-menu-item>
         <md-menu-divider></md-menu-divider>
         <md-menu-item>
-            <md-button ng-click="ctrl.setStage('DEV')">
-                <md-icon md-font-set="material-icons" md-menu-align-target>motorcycle</md-icon>
-                DEV
+            <md-button ng-click="ctrl.setStage('PROD')">
+                <md-icon md-font-set="material-icons" md-menu-align-target>check_circle</md-icon>
+                PROD
             </md-button>
         </md-menu-item>
         <md-menu-item>
             <md-button ng-click="ctrl.setStage('UAT')">
-                <md-icon md-font-set="material-icons" md-menu-align-target>supervisor_account</md-icon>
+                <md-icon md-font-set="material-icons" md-menu-align-target>bug_report</md-icon>
                 UAT
             </md-button>
         </md-menu-item>
         <md-menu-item>
-            <md-button ng-click="ctrl.setStage('PROD')">
-                <md-icon md-font-set="material-icons" md-menu-align-target>business</md-icon>
-                PROD
+            <md-button ng-click="ctrl.setStage('DEV')">
+                <md-icon md-font-set="material-icons" md-menu-align-target>build</md-icon>
+                DEV
             </md-button>
         </md-menu-item>
     </md-menu-content>

--- a/frontend/src/templates/GridImageSelector.html
+++ b/frontend/src/templates/GridImageSelector.html
@@ -1,4 +1,4 @@
-<modal show="show" product="product">
+<modal show="show" campaign-group="campaignGroup">
     <iframe ng-src="{{gridUrl}}" height="1200px" width="100%" style="border: none"></iframe>
 </modal>
 

--- a/frontend/src/templates/Modal.html
+++ b/frontend/src/templates/Modal.html
@@ -1,6 +1,6 @@
 <div class="modal__backdrop" ng-show="show" ng-click="show = !show"></div>
 <div class="modal" layout="column" flex ng-show="show">
-    <md-toolbar ng-class="product">
+    <md-toolbar ng-class="campaignGroup">
         <div class="md-toolbar-tools">
             <h2>The Grid</h2>
             <span flex></span>

--- a/frontend/src/templates/MultiPromotionType.html
+++ b/frontend/src/templates/MultiPromotionType.html
@@ -1,14 +1,14 @@
 <ng-form name="promoType" layout="column">
 
-    <promotion-type promotion-type="promotion.promotionType" product="environment.product" ng-if="!promotion.promotionType.a"></promotion-type>
+    <promotion-type promotion-type="promotion.promotionType" campaign-group="environment.campaignGroup" ng-if="!promotion.promotionType.a"></promotion-type>
 
 
     <div layout="row" layout-align="start">
         <md-button ng-if="!promotion.promotionType.a" ng-click="ctrl.makeMulti(promotion.promotionType)">Add additional type</md-button>
     </div>
 
-    <promotion-type promotion-type="promotion.promotionType.a" product="environment.product" ng-if="promotion.promotionType.a"></promotion-type>
-    <promotion-type promotion-type="promotion.promotionType.b" product="environment.product" ng-if="promotion.promotionType.b"></promotion-type>
+    <promotion-type promotion-type="promotion.promotionType.a" campaign-group="environment.campaignGroup" ng-if="promotion.promotionType.a"></promotion-type>
+    <promotion-type promotion-type="promotion.promotionType.b" campaign-group="environment.campaignGroup" ng-if="promotion.promotionType.b"></promotion-type>
 
 
 </ng-form>

--- a/frontend/src/templates/PromotionForm.html
+++ b/frontend/src/templates/PromotionForm.html
@@ -19,12 +19,12 @@
                         <ng-message when="required">Please enter a description</ng-message>
                     </div>
                 </md-input-container>
-                <multi-promotion-type promotion="promotion" product="environment.product"></multi-promotion-type>
-                <rate-plan-list product-rate-plan-ids="promotion.appliesTo.productRatePlanIds" product="environment.product"></rate-plan-list>
+                <multi-promotion-type promotion="promotion" campaign-group="environment.campaignGroup"></multi-promotion-type>
+                <rate-plan-list product-rate-plan-ids="promotion.appliesTo.productRatePlanIds" campaign-group="environment.campaignGroup"></rate-plan-list>
                 <available-countries countries="promotion.appliesTo.countries"></available-countries>
                 <promotion-dates promotion="promotion"></promotion-dates>
                 <channel-codes codes="promotion.codes"></channel-codes>
-                <landing-page promotion="promotion" product="environment.product"></landing-page>
+                <landing-page promotion="promotion" campaign-group="environment.campaignGroup"></landing-page>
 
                 <section layout="row" layout-align="end center" layout-wrap>
                     <div layout="column" layout-align="center center">

--- a/frontend/src/templates/PromotionList.html
+++ b/frontend/src/templates/PromotionList.html
@@ -7,7 +7,7 @@
             <div class="md-list-item-text promotion-list-item" layout="column">
                 <h3 ui-sref="promotion({uuid: promotion.uuid})">{{ promotion.name }}</h3>
                 <h4 ui-sref="promotion({uuid: promotion.uuid})" class="promotion-code-list">
-                    <span ng-repeat="(channel, code) in promotion.codes">{{ code.join(", ") }}&nbsp;</span>
+                    <p ng-repeat="(channel, code) in promotion.codes">{{ code.join(", ") }}&nbsp;</p>
                 </h4>
                 <p ui-sref="promotion({uuid: promotion.uuid})">
                     <md-icon md-font-set="material-icons">date_range</md-icon>

--- a/frontend/src/templates/PromotionType.html
+++ b/frontend/src/templates/PromotionType.html
@@ -50,7 +50,7 @@
         <!-- Tracking -->
         <md-tab label="Tracking" ng-click="ctrl.setPromotionType('tracking')">
             <md-content class="md-padding md-tab-content">
-                <p ng-show="product == 'membership'">For Tracking promotions, the <b>Rate plans</b> below are only used to choose the landing page tier.</p>
+                <p ng-show="campaignGroup == 'membership'">For Tracking promotions, the <b>Rate plans</b> below are only used to choose the landing page tier.</p>
             </md-content>
         </md-tab>
     </md-tabs>

--- a/frontend/src/templates/RatePlanList.html
+++ b/frontend/src/templates/RatePlanList.html
@@ -1,4 +1,4 @@
-<div layout="column" ng-repeat="(planKey, plans) in ratePlans" ng-show="planKey == product">
+<div layout="column" ng-repeat="(planKey, plans) in ratePlans" ng-show="planKey == campaignGroup">
     <h5>Rate plans</h5>
     <div>
         <md-checkbox ng-model="ratePlanIds[plan.ratePlanId]" aria-label="{{plan.ratePlanName}}" ng-repeat="plan in plans" ng-change="ctrl.applyRatePlans(ratePlanIds)">

--- a/lambdas/MembershipSub-Promotions-to-PromoCode-View-Lambda.js
+++ b/lambdas/MembershipSub-Promotions-to-PromoCode-View-Lambda.js
@@ -109,7 +109,7 @@ exports.handler = (event, context, callback) => {
         data.Items.forEach((campaign) =>
             campaignDetailsByCampaignCode[campaign.code] = {
                 campaign_name: campaign.name,
-                product_family: campaign.productFamily
+                product_family: campaign.group || campaign.productFamily // legacy
             }
         );
 

--- a/lambdas/MembershipSub-Promotions-to-PromoCode-View-Lambda.js
+++ b/lambdas/MembershipSub-Promotions-to-PromoCode-View-Lambda.js
@@ -109,7 +109,7 @@ exports.handler = (event, context, callback) => {
         data.Items.forEach((campaign) =>
             campaignDetailsByCampaignCode[campaign.code] = {
                 campaign_name: campaign.name,
-                product_family: campaign.group || campaign.productFamily // legacy
+                product_family: campaign.group || campaign.product_family // legacy
             }
         );
 

--- a/lambdas/MembershipSub-Promotions-to-PromoCode-View-Lambda.js
+++ b/lambdas/MembershipSub-Promotions-to-PromoCode-View-Lambda.js
@@ -109,7 +109,7 @@ exports.handler = (event, context, callback) => {
         data.Items.forEach((campaign) =>
             campaignDetailsByCampaignCode[campaign.code] = {
                 campaign_name: campaign.name,
-                product_family: campaign.group || campaign.product_family // legacy
+                product_family: campaign.group || campaign.productFamily // legacy
             }
         );
 


### PR DESCRIPTION
- Updated to latest membership common so that I could leverage the new CampaignGroup and expand the number of filters for the campaigns. This means the business can have a view of Newspaper and Guardian Weekly promotions separate to just Digital Pack and Membership.
- There was a lot of collateral renaming .product to .campaignGroup.
- A few UI tweaks for fonts, colours and icons.
- Still want to have a 'check all' button for Rate Plans and Countries, but will roll that into the next phase.
- Still need to add correct rate plan IDs for Guardian Weekly.

cc @tomverran @pvighi @johnduffell 