### PR TITLE
Update to latest membership common to fix that LandingPage was being …

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -29,7 +29,7 @@ libraryDependencies ++= Seq(
   cache,
   ws,
   "org.scalaz" %% "scalaz-core" % "7.1.3",
-  "com.gu" %% "membership-common" % "0.275",
+  "com.gu" %% "membership-common" % "0.276",
   "com.gu" %% "memsub-common-play-auth" % "0.7",
   "com.softwaremill.macwire" %% "macros" % "2.2.2" % "provided",
   "com.softwaremill.macwire" %% "util" % "2.2.2",

--- a/frontend/sass/main.sass
+++ b/frontend/sass/main.sass
@@ -42,11 +42,13 @@ md-tabs
   cursor: pointer
 
 md-toolbar
-  background-color: #00456e
   cursor: pointer
   transition: background-color 0.5s
   transition-delay: 0.2s
   text-transform: capitalize
+
+md-toolbar.prod
+  background-color: #00456e
 
 md-toolbar.uat
   background-color: #d61d00


### PR DESCRIPTION
Update to latest membership common to fix that LandingPage's type was being serialised in a non-backwards compatibile way (using 'type' rather than 'productFamily').

cc @tomverran 