### PR TITLE
Promo tool support for voucher launch activities

### DIFF
--- a/frontend/src/controllers/ChannelCodesController.es6
+++ b/frontend/src/controllers/ChannelCodesController.es6
@@ -4,6 +4,7 @@ export default class {
     constructor($scope, environmentService) {
         this.$scope = $scope;
         this.environmentService = environmentService;
+        this.$scope.campaignGroup = this.environmentService.getCampaignGroup();
         this.$scope.campaignGroupDomain = this.environmentService.getCampaignGroupDomain();
     }
 

--- a/frontend/src/controllers/EditCampaignController.es6
+++ b/frontend/src/controllers/EditCampaignController.es6
@@ -27,7 +27,7 @@ export default class {
 
     save(campaign) {
         this.campaignService.save(campaign).then(
-            this.$state.go('allPromotions.singleCampaign', {code: campaign.code})
+            this.$state.go('allPromotions.chooseCampaign', {}, {reload: true})
         );
     }
 }

--- a/frontend/src/controllers/PromotionFormController.es6
+++ b/frontend/src/controllers/PromotionFormController.es6
@@ -4,8 +4,7 @@ const emptyPromotion = {
     countries: []
   },
   codes: {},
-  promotionType: { name: "tracking" },
-  landingPage: {}
+  promotionType: { name: "tracking" }
 };
 
 export default class {
@@ -21,6 +20,7 @@ export default class {
         this.$q = $q;
 
         this.$scope.serverErrors = [];
+        this.$scope.campaignGroup = this.environmentService.getCampaignGroup();
         this.$scope.campaignGroupDomain = this.environmentService.getCampaignGroupDomain();
 
         if ($stateParams.uuid) {
@@ -33,9 +33,12 @@ export default class {
     }
 
     createNewPromotion(campaignCode) {
-        this.$scope.promotion = Object.assign({}, emptyPromotion, 
-            {campaignCode: campaignCode, uuid: this.uuid.v4()},
-            {landingPage: {type: this.environmentService.getCampaignGroup()}});
+        const campaignCodeStub = {campaignCode: campaignCode, uuid: this.uuid.v4()};
+        var landingPageStub = null;
+        if (this.$scope.campaignGroup === 'digitalpack') {
+            landingPageStub = {landingPage: {type: this.environmentService.getCampaignGroup()}}
+        }
+        this.$scope.promotion = Object.assign({}, emptyPromotion, campaignCodeStub, landingPageStub);
         return this.fillCampaignInfo(this.$scope.promotion)
     }
 
@@ -76,8 +79,20 @@ export default class {
     save(promotion) {
         this.$scope.serverErrors = [];
         this.service.validate(promotion)
-            .then(valid => this.update(valid).then(() => this.$state.go('allPromotions.singleCampaign', {code: promotion.campaignCode})), 
-                  invalid => this.$scope.serverErrors = invalid)
+            .then(
+                  valid => this.update(valid),
+                invalid => this.$scope.serverErrors = invalid
+            )
+
+    }
+
+    close(promotion) {
+        this.$scope.serverErrors = [];
+        this.service.validate(promotion)
+            .then(
+                    valid => this.update(valid).then(() => this.$state.go('allPromotions.singleCampaign', {code: promotion.campaignCode})),
+                  invalid => this.$scope.serverErrors = invalid
+            )
             
     }
 }

--- a/frontend/src/templates/ChannelCodes.html
+++ b/frontend/src/templates/ChannelCodes.html
@@ -18,7 +18,10 @@
                 </ng-form>
                 <div>
                     <md-input-container ng-repeat="code in channel.codes track by $index" class="code-container">
-                        <md-icon md-font-set="material-icons" md-menu-align-target><a target="_blank" href="https://{{ campaignGroupDomain }}/p/{{ channel.codes[$index] }}">open_in_browser</a></md-icon>
+                        <md-icon md-font-set="material-icons" md-menu-align-target>
+                            <a ng-if="campaignGroup === 'digitalpack'" target="_blank" href="https://{{ campaignGroupDomain }}/p/{{ channel.codes[$index] }}">open_in_browser</a>
+                            <a ng-if="campaignGroup === 'newspaper'" target="_blank" href="https://{{ campaignGroupDomain }}/checkout/voucher-sunday+?promoCode={{ channel.codes[$index] }}">open_in_browser</a>
+                        </md-icon>
                         <label for="code">Promo Code</label>
                         <input type="text" id="code" ng-model="channel.codes[$index]" ng-change="ctrl.codeUpdated(channels, channel.name, channel.codes[$index])">
                     </md-input-container>

--- a/frontend/src/templates/PromotionForm.html
+++ b/frontend/src/templates/PromotionForm.html
@@ -19,16 +19,17 @@
                         <ng-message when="required">Please enter a description</ng-message>
                     </div>
                 </md-input-container>
-                <multi-promotion-type promotion="promotion" campaign-group="environment.campaignGroup"></multi-promotion-type>
-                <rate-plan-list product-rate-plan-ids="promotion.appliesTo.productRatePlanIds" campaign-group="environment.campaignGroup"></rate-plan-list>
+                <multi-promotion-type promotion="promotion" campaign-group="campaignGroup"></multi-promotion-type>
+                <rate-plan-list product-rate-plan-ids="promotion.appliesTo.productRatePlanIds" campaign-group="campaignGroup"></rate-plan-list>
                 <available-countries countries="promotion.appliesTo.countries"></available-countries>
                 <promotion-dates promotion="promotion"></promotion-dates>
                 <channel-codes codes="promotion.codes"></channel-codes>
-                <landing-page promotion="promotion" campaign-group="environment.campaignGroup"></landing-page>
+                <landing-page ng-if="campaignGroup === 'digitalpack'" promotion="promotion" campaign-group="campaignGroup"></landing-page>
 
                 <section layout="row" layout-align="end center" layout-wrap>
-                    <div layout="column" layout-align="center center">
-                        <md-button type="submit" class="md-raised md-primary">Save and Close</md-button>
+                    <div layout="row" layout-align="center center">
+                        <md-button type="submit" class="md-raised md-primary">Save</md-button>
+                        <md-button class="md-raised md-primary" ng-click="ctrl.close(promotion)">Save & Close</md-button>
                         <div class="small-error" ng-show="promotionForm.$submitted && promotionForm.$invalid">
                             This form has errors
                         </div>
@@ -43,5 +44,5 @@
             </div>
         </form>
     </div>
-    <preview-promotion flex layout="column" promotion="promotion" validity="promotionForm.$valid"></preview-promotion>
+    <preview-promotion ng-if="campaignGroup === 'digitalpack'" flex layout="column" promotion="promotion" validity="promotionForm.$valid"></preview-promotion>
 </div>


### PR DESCRIPTION
Changes to the promo tool to support voucher launch activities:
- New Campaign displays in listing after creating it.
- Link next to promo code to checkout page for voucher, rather than only digipack.
- Save button sits alongside Save & Close in order to wait the 15 seconds for the promo to make it onto prod.
- Hide the landing page option for non-Digipack promos to save having to always untick it each time.

cc @pvighi @AWare 