### PR TITLE
Promo tool updates for voucher promo launch

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -29,7 +29,7 @@ libraryDependencies ++= Seq(
   cache,
   ws,
   "org.scalaz" %% "scalaz-core" % "7.1.3",
-  "com.gu" %% "membership-common" % "0.295",
+  "com.gu" %% "membership-common" % "0.296",
   "com.gu" %% "memsub-common-play-auth" % "0.7",
   "com.softwaremill.macwire" %% "macros" % "2.2.2" % "provided",
   "com.softwaremill.macwire" %% "util" % "2.2.2",

--- a/build.sbt
+++ b/build.sbt
@@ -29,7 +29,7 @@ libraryDependencies ++= Seq(
   cache,
   ws,
   "org.scalaz" %% "scalaz-core" % "7.1.3",
-  "com.gu" %% "membership-common" % "0.276",
+  "com.gu" %% "membership-common" % "0.295",
   "com.gu" %% "memsub-common-play-auth" % "0.7",
   "com.softwaremill.macwire" %% "macros" % "2.2.2" % "provided",
   "com.softwaremill.macwire" %% "util" % "2.2.2",

--- a/frontend/src/controllers/PromotionFormController.es6
+++ b/frontend/src/controllers/PromotionFormController.es6
@@ -34,10 +34,7 @@ export default class {
 
     createNewPromotion(campaignCode) {
         const campaignCodeStub = {campaignCode: campaignCode, uuid: this.uuid.v4()};
-        var landingPageStub = null;
-        if (this.$scope.campaignGroup === 'digitalpack') {
-            landingPageStub = {landingPage: {type: this.environmentService.getCampaignGroup()}}
-        }
+        var landingPageStub = {landingPage: {type: this.environmentService.getCampaignGroup()}};
         this.$scope.promotion = Object.assign({}, emptyPromotion, campaignCodeStub, landingPageStub);
         return this.fillCampaignInfo(this.$scope.promotion)
     }

--- a/frontend/src/templates/ChannelCodes.html
+++ b/frontend/src/templates/ChannelCodes.html
@@ -19,8 +19,7 @@
                 <div>
                     <md-input-container ng-repeat="code in channel.codes track by $index" class="code-container">
                         <md-icon md-font-set="material-icons" md-menu-align-target>
-                            <a ng-if="campaignGroup === 'digitalpack'" target="_blank" href="https://{{ campaignGroupDomain }}/p/{{ channel.codes[$index] }}">open_in_browser</a>
-                            <a ng-if="campaignGroup === 'newspaper'" target="_blank" href="https://{{ campaignGroupDomain }}/checkout/voucher-sunday+?promoCode={{ channel.codes[$index] }}">open_in_browser</a>
+                            <a target="_blank" href="https://{{ campaignGroupDomain }}/p/{{ channel.codes[$index] }}/terms">open_in_new</a>
                         </md-icon>
                         <label for="code">Promo Code</label>
                         <input type="text" id="code" ng-model="channel.codes[$index]" ng-change="ctrl.codeUpdated(channels, channel.name, channel.codes[$index])">

--- a/frontend/src/templates/LandingPage.html
+++ b/frontend/src/templates/LandingPage.html
@@ -5,7 +5,15 @@
         This promotion has a landing page
     </md-checkbox>
 
-    <div layout="column" ng-show="promotion.landingPage !== undefined">
+    <div layout="column" ng-show="promotion.landingPage !== undefined" ng-if="newspaper">
+        <h5>Default product</h5>
+        <md-radio-group layout="row" ng-model="promotion.landingPage.defaultProduct">
+            <md-radio-button value="voucher" class="md-primary" ng-checked="true">Voucher</md-radio-button>
+            <md-radio-button value="delivery">Home Delivery</md-radio-button>
+        </md-radio-group>
+    </div>
+
+    <div layout="column" ng-show="promotion.landingPage !== undefined" ng-if="!newspaper">
         <grid-image-selector image="promotion.landingPage.heroImage.image" label="a hero image" ng-if="membership" change="ctrl.heroImageChange(promotion.landingpage.heroImage.alignment)"></grid-image-selector>
         <div layout="column" ng-show="membership && promotion.landingPage.heroImage !== undefined">
             <h5>Hero image alignment</h5>

--- a/frontend/src/templates/PromotionForm.html
+++ b/frontend/src/templates/PromotionForm.html
@@ -24,7 +24,7 @@
                 <available-countries countries="promotion.appliesTo.countries"></available-countries>
                 <promotion-dates promotion="promotion"></promotion-dates>
                 <channel-codes codes="promotion.codes"></channel-codes>
-                <landing-page ng-if="campaignGroup === 'digitalpack'" promotion="promotion" campaign-group="campaignGroup"></landing-page>
+                <landing-page promotion="promotion" campaign-group="campaignGroup"></landing-page>
 
                 <section layout="row" layout-align="end center" layout-wrap>
                     <div layout="row" layout-align="center center">

--- a/frontend/src/templates/PromotionList.html
+++ b/frontend/src/templates/PromotionList.html
@@ -4,12 +4,12 @@
             Promotions <md-icon class="add-button" md-font-set="material-icons" ui-sref="createPromotion({campaignCode: code})">add</md-icon>
         </md-subheader>
         <md-list-item class="md-3-line md-clickable" ng-repeat="promotion in promotions" md-ink-ripple="#AAAAAA">
-            <div class="md-list-item-text promotion-list-item" layout="column">
-                <h3 ui-sref="promotion({uuid: promotion.uuid})">{{ promotion.name }}</h3>
-                <h4 ui-sref="promotion({uuid: promotion.uuid})" class="promotion-code-list">
-                    <p ng-repeat="(channel, code) in promotion.codes">{{ code.join(", ") }}&nbsp;</p>
+            <div class="md-list-item-text promotion-list-item" layout="column"  ui-sref="promotion({uuid: promotion.uuid})">
+                <h3>{{ promotion.name }}</h3>
+                <h4 class="promotion-code-list">
+                    <p ng-repeat="(channel, codes) in promotion.codes">{{ channel }}: {{ codes.join(", ") }}</p>
                 </h4>
-                <p ui-sref="promotion({uuid: promotion.uuid})">
+                <p>
                     <md-icon md-font-set="material-icons">date_range</md-icon>
                     {{ promotion.starts | date:"dd MMM yy" }} - {{ promotion.expires | date:"dd MMM yy" }}
                 </p>

--- a/frontend/src/templates/PromotionType.html
+++ b/frontend/src/templates/PromotionType.html
@@ -13,8 +13,12 @@
                     </div>
                 </md-input-container>
                 <md-input-container class="md-block" flex-gt-sm>
-                    <label>Terms and conditions</label>
+                    <label>Short terms and conditions</label>
                     <textarea ng-model="promotionType.termsAndConditions" delete-empty></textarea>
+                </md-input-container>
+                <md-input-container class="md-block" flex-gt-sm>
+                    <label>Long terms and conditions</label>
+                    <textarea ng-model="promotionType.legalTerms" delete-empty></textarea>
                 </md-input-container>
             </md-content>
         </md-tab>


### PR DESCRIPTION
- Added new "Long terms and conditions" field to Incentive promotions.
- Added the channel name prefix to the list of codes under a promotion. See pic below.
- Updated promo code link to go to /terms page as that will always show, even if the promotion has expired or is not yet active.
- Ensured we use the new 'type' field for setting up the landing page angular model, deprecating the old 'productFamily'.
- Let the lading page area show either Voucher or Home Delivery for newspaper promotions

![picture 241](https://cloud.githubusercontent.com/assets/1515970/19802348/2a740e6e-9cfb-11e6-914d-685401b73720.png)

![picture 242](https://cloud.githubusercontent.com/assets/1515970/19802370/3ee31f52-9cfb-11e6-8b75-6073da1d2c68.png)

![picture 243](https://cloud.githubusercontent.com/assets/1515970/19802398/570933f0-9cfb-11e6-974d-4757694288ec.png)

cc @AWare @johnduffell @pvighi @jacobwinch 