### PR TITLE
Make start date and end date for promotions be at the beginning and end of the respective days

### DIFF
--- a/app/controllers/PromotionController.scala
+++ b/app/controllers/PromotionController.scala
@@ -1,25 +1,40 @@
 package controllers
 
-import java.util.UUID
+import java.util.{TimeZone, UUID}
 
-import actions.GoogleAuthAction
 import actions.GoogleAuthAction._
-import com.gu.memsub.promo._
-import com.gu.memsub.promo.Promotion.AnyPromotion
-import play.api.libs.concurrent.Execution.Implicits._
-import com.gu.memsub.services.JsonDynamoService
-import com.gu.memsub.promo.Formatters.PromotionFormatters._
 import com.gu.memsub.promo.Formatters.Common._
+import com.gu.memsub.promo.Formatters.PromotionFormatters._
+import com.gu.memsub.promo.Promotion.AnyPromotion
+import com.gu.memsub.promo._
+import com.gu.memsub.services.JsonDynamoService
+import org.joda.time.DateTimeZone
 import play.api.data.validation.ValidationError
+import play.api.libs.concurrent.Execution.Implicits._
 import play.api.libs.json.{JsError, JsPath, Json}
-import play.api.mvc.{Action, Result}
-
-import scala.concurrent.Future
+import play.api.mvc.Result
 import play.api.mvc.Results._
 
+import scala.concurrent.Future
 import scala.util.Try
 
 class PromotionController(googleAuthAction: GoogleAuthenticatedAction, service: JsonDynamoService[AnyPromotion, Future]) {
+
+  private val londonTimezone = DateTimeZone.forTimeZone(TimeZone.getTimeZone("Europe/London"))
+
+  /**
+    * Only dates are shown on screen on the promo tool (with a timezone local to the user's laptop), so the start datetime
+    * will be normalised to being at the start of the London day, and the end datetime will be normalised to being at the
+    * end of the London day.
+    * @param promotion the promotion object marshalled from the frontend POST
+    * @return a copy of the promotion with its dates normalised.
+    */
+  private def normaliseDateTimes(promotion: AnyPromotion): AnyPromotion = {
+    promotion.copy(
+      starts = promotion.starts.withZone(londonTimezone).withTimeAtStartOfDay,
+      expires = promotion.expires.map(_.withZone(londonTimezone).withTimeAtStartOfDay.plusDays(1).minusSeconds(1))
+    )
+  }
 
   def all(campaignCode: Option[String]) = googleAuthAction.async {
     campaignCode.map(CampaignCode).fold(service.all)(service.find).map(promos => Ok(Json.toJson(promos.sortBy(_.starts.getMillis).reverse)))
@@ -41,7 +56,7 @@ class PromotionController(googleAuthAction: GoogleAuthenticatedAction, service: 
   def upsert = googleAuthAction.async { request =>
     request.body.asJson.map { json =>
       json.validate[AnyPromotion].map { promotion => {
-        service.add(promotion).map(_ => Ok(Json.obj("status" -> "ok")))
+        service.add(normaliseDateTimes(promotion)).map(_ => Ok(Json.obj("status" -> "ok")))
       }
       }.recoverTotal{
         e => Future(BadRequest("Detected error:"+ JsError.toJson(e)))


### PR DESCRIPTION
- Ensured that the timezone saved in dynamo for a promotion's start and end date time most likely matches that of the user using the promo code tool.
- Forced that the promotion start datetime is at the beginning of the day and that that the promotion end datetime is at the end of the day, thus making the dates on screen be 'inclusive'.

https://trello.com/c/k7Tcb6B5/88-fix-times-for-dates-shown-in-promo-tool

cc @AWare @JuliaBellis 