### PR TITLE
Sort the promotions within a campaign by name not by their latest start date

### DIFF
--- a/app/controllers/PromotionController.scala
+++ b/app/controllers/PromotionController.scala
@@ -37,7 +37,7 @@ class PromotionController(googleAuthAction: GoogleAuthenticatedAction, service: 
   }
 
   def all(campaignCode: Option[String]) = googleAuthAction.async {
-    campaignCode.map(CampaignCode).fold(service.all)(service.find).map(promos => Ok(Json.toJson(promos.sortBy(_.starts.getMillis).reverse)))
+    campaignCode.map(CampaignCode).fold(service.all)(service.find).map(promos => Ok(Json.toJson(promos.sortBy(_.name))))
   }
 
   def get(uuid: Option[String]) = googleAuthAction.async {


### PR DESCRIPTION
I've decided that we should sort the promotions within a campaign by name not by their latest start date. This lets people manage series of promotions (like Guardian Weekly renewals) better.

cc @AWare 