### PR TITLE
Sort the channel names and promo codes alphanumerically

### DIFF
--- a/frontend/src/services/PromotionService.es6
+++ b/frontend/src/services/PromotionService.es6
@@ -6,11 +6,23 @@ export default class {
         this.$q = $q;
     }
 
+    sortChannelKeysAndPromoCodes(promotion) {
+        const channelKeys = Array.sort(Object.keys(promotion.codes));
+        const codes = {};
+        channelKeys.forEach(channel => {
+            codes[channel] = Array.sort(promotion.codes[channel]); // Hack! Also sorts the object keys!
+        });
+        promotion.codes = codes;
+        return promotion;
+    }
+
     all() {
         return this.$http({
             method: 'GET',
             url: '/promotions'
-        }).then(response => response.data)
+        })
+        .then(response => response.data)
+        .then(promotions => promotions.map(this.sortChannelKeysAndPromoCodes));
     }
 
     get(uuid) {
@@ -18,7 +30,7 @@ export default class {
             method: 'GET',
             url: '/promotion',
             params: {uuid: uuid}
-        }).then(response => response.data)
+        }).then(response => this.sortChannelKeysAndPromoCodes(response.data))
     }
 
     byCampaign(campaignCode) {
@@ -26,14 +38,16 @@ export default class {
             method: 'GET',
             url: '/promotions',
             params: {campaignCode: campaignCode}
-        }).then(response => response.data)
+        })
+        .then(response => response.data)
+        .then(promotions => promotions.map(this.sortChannelKeysAndPromoCodes));
     }
 
     save(promotion) {
         return this.$http({
             method: 'POST',
             url: '/promotion',
-            data: promotion
+            data: this.sortChannelKeysAndPromoCodes(promotion)
         }).then(response => response.data)
     }
 


### PR DESCRIPTION
Added a function at the service layer to sort the channel names and promo codes lexicographically, to make the date in the UI easier for the human eye to skim over.

Before:
![picture 10](https://cloud.githubusercontent.com/assets/1515970/21384559/f100eaca-c762-11e6-99b3-2b5250653a07.png)
![picture 12](https://cloud.githubusercontent.com/assets/1515970/21384558/f0fea15c-c762-11e6-80a2-c362ca5f05ac.png)

After:
![picture 11](https://cloud.githubusercontent.com/assets/1515970/21384565/f66aa4ce-c762-11e6-98ec-9b744f345541.png)
![picture 13](https://cloud.githubusercontent.com/assets/1515970/21384566/f66b8b0a-c762-11e6-9afd-9109cbaeef6d.png)

cc @AWare 