### PR TITLE
Added a Description field to a newspaper landing page

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -22,14 +22,15 @@ lazy val root = (project in file(".")).enablePlugins(
 )
 
 
-scalaVersion := "2.11.7"
+scalaVersion := "2.11.8"
+scalacOptions ++= Seq("-feature")
 
 libraryDependencies ++= Seq(
   jdbc,
   cache,
   ws,
   "org.scalaz" %% "scalaz-core" % "7.1.3",
-  "com.gu" %% "membership-common" % "0.325",
+  "com.gu" %% "membership-common" % "0.338",
   "com.gu" %% "memsub-common-play-auth" % "0.7",
   "com.softwaremill.macwire" %% "macros" % "2.2.2" % "provided",
   "com.softwaremill.macwire" %% "util" % "2.2.2",

--- a/frontend/src/templates/LandingPage.html
+++ b/frontend/src/templates/LandingPage.html
@@ -6,6 +6,10 @@
     </md-checkbox>
 
     <div layout="column" ng-show="promotion.landingPage !== undefined" ng-if="newspaper">
+        <md-input-container>
+            <label>Description</label>
+            <textarea name="landing-description" ng-model="promotion.landingPage.description" delete-empty></textarea>
+        </md-input-container>
         <h5>Default product</h5>
         <md-radio-group layout="row" ng-model="promotion.landingPage.defaultProduct">
             <md-radio-button value="voucher" class="md-primary" ng-checked="true">Voucher</md-radio-button>

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,4 +1,4 @@
 #Activator-generated Properties
 #Wed Apr 27 13:51:21 BST 2016
 template.uuid=86f70d51-c929-4089-b3cd-cd0e266e7c01
-sbt.version=0.13.11
+sbt.version=0.13.13


### PR DESCRIPTION
- Added a Description field to a newspaper landing page model, to render on the Newspaper landing page in subscriptions-frontend: https://github.com/guardian/subscriptions-frontend/pull/756
- Also updated to latest SBT and use same Scala version as membership-common.

![picture 7](https://cloud.githubusercontent.com/assets/1515970/21716787/a88089a0-d404-11e6-9fd6-d80e73e00a3e.png)

cc @AWare @johnduffell 