### PR TITLE
Updated README and nginx config

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,43 +3,53 @@ Memsubity promotions
 
 ### NGinx
 
-   To run standalone you can use the default nginx installation as follows:
+#### First, setup Nginx for `Identity-Platform`
 
-   Install nginx:
+Set up Nginx config and SSL certs from Identity. Follow the README
+[here](https://github.com/guardian/identity-platform/blob/master/README.md#setup-nginx-for-local-development)
+first, before you do anything else but make sure to pass the profile 'membership' to the script:
 
-   Mac OSX: `brew install nginx`
+Within `identity-platform`, run: 
+   ```
+   sudo -E nginx/setup.sh membership --with-jdk-import
+   ```
+and enter your password where prompted.
 
-   Make sure you have a sites-enabled folder under your nginx home. This should be
+#### Then, run the Nginx setup script specific to `memsub-promotions`
 
-   Mac OSX: `~/Developers/etc/nginx/sites-enabled` or `/usr/local/etc/nginx/`
-   Make sure your nginx.conf (found in your nginx home) contains the following line in the `http{...}` block: `include sites-enabled/*`;
+Run the `memsub-promotions`-specific [setup.sh](nginx/setup.sh) script from the root
+of the `memsub-promotions` project:
 
-   Run: `./nginx/setup.sh`
+```
+./nginx/setup.sh
+```
 
-   ## General Setup
+## General Setup
 
-   1. Go to project root
-   1. Add the following to your hosts file in `/etc/hosts`
+1. Go to project root
+1. Add the following to your hosts file in `/etc/hosts`
 
-      ```
-      127.0.0.1   promo.thegulocal.com
-      ```
+   ```
+   127.0.0.1   promo.thegulocal.com
+   ```
+1. Change the ownership of the 'gu' directory under 'etc' to current user.
+   `$ sudo -i chown -R {username} /etc/gu`
+   
+1. Setup AWS credentials with [Janus](https://janus.gutools.co.uk/).
 
-   1. Change the ownership of the 'gu' directory under 'etc' to current user.
-      `$ sudo -i chown -R {username} /etc/gu`
-      
-   1. Run `./nginx/setup.sh`
+   In `~/.aws/config` add the following:
 
-   1. Setup AWS credentials with [Janus](https://janus.gutools.co.uk/).
-
-      In `~/.aws/config` add the following:
-
-      ```
-      [default]
-      region = eu-west-1
-      ```
-
-   1. Run ``` sbt devrun ``` and navigate to ```promo.thegulocal.com```
+   ```
+   [default]
+   region = eu-west-1
+   ```
+   
+1. Download our private keys from the gu-promotions-tool-private S3 bucket. If you have the AWS CLI set up you can run:
+   ```
+   aws s3 cp s3://gu-promotions-tool-private/DEV/memsub-promotions-keys.conf /etc/gu  --profile membership
+   ```
+   
+1. Run ``` sbt devrun ``` and navigate to ```promo.thegulocal.com```
 
 ### Lambdas
 

--- a/nginx/promotions.conf
+++ b/nginx/promotions.conf
@@ -12,8 +12,8 @@ server {
     server_name promo.thegulocal.com;
 
     ssl on;
-    ssl_certificate keys/promo-thegulocal-com-exp2017-04-28-bundle.crt;
-    ssl_certificate_key keys/promo-thegulocal-com-exp2017-04-28.key;
+    ssl_certificate keys/wildcard-thegulocal-com-exp2019-01-09.crt;
+    ssl_certificate_key keys/wildcard-thegulocal-com-exp2019-01-09.key;
 
     ssl_session_timeout 5m;
 

--- a/nginx/setup.sh
+++ b/nginx/setup.sh
@@ -1,15 +1,10 @@
 #!/bin/bash
-
-GU_KEYS="${HOME}/.gu/keys"
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 NGINX_HOME=$(nginx -V 2>&1 | grep 'configure arguments:' | sed 's#.*conf-path=\([^ ]*\)/nginx\.conf.*#\1#g')
 
+echo "this script needs root access to configure nginx, please enter your sudo password if prompted"
 sudo mkdir -p $NGINX_HOME/sites-enabled
 sudo ln -fs $DIR/promotions.conf $NGINX_HOME/sites-enabled/promotions.conf
-
-aws s3 cp s3://identity-local-ssl/promo-thegulocal-com-exp2017-04-28-bundle.crt ${GU_KEYS}/ --profile membership
-aws s3 cp s3://identity-local-ssl/promo-thegulocal-com-exp2017-04-28.key ${GU_KEYS}/ --profile membership
-sudo ln -fs ${GU_KEYS}/ $NGINX_HOME/keys
 
 sudo nginx -s stop
 sudo nginx


### PR DESCRIPTION
What I've learned while getting memsubs-promotions running locally:
+ The certificate and key in the nginx config promotions.conf are now expired, but we can use the wildcard certificate and key from the identity platform config
+ Where to find the private dev config in S3

So, 
+ I've updated the nginx setup instructions to point to setting up nginx in identity-platform 
+ and so also now the nginx setup for this project can just add promotions.conf and start nginx
+ Updated cert and key in promotions.conf to point to the ones added by setting up identity-platform
+ Now the README points to where to download the config from S3