### PR TITLE
Correct structure for generated artifact

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,4 @@
-name := """memsub-promotions"""
+name := """promotions-tool"""
 
 version := "1.0-SNAPSHOT"
 

--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,4 @@
-name := """promotions-tool"""
+name := """memsub-promotions"""
 
 version := "1.0-SNAPSHOT"
 

--- a/cloudformation/memsub-promotions-cf.json
+++ b/cloudformation/memsub-promotions-cf.json
@@ -428,7 +428,7 @@
 
                     { "Fn::Join": [ "", ["/opt/features/ssh-keys/initialise-keys-and-cron-job.sh -l -b github-team-keys -t ", {"Ref":"GithubTeamName"}, "|| true"] ] },
 
-                    "CONF_DIR=/etc/memsub-promotions",
+                    "CONF_DIR=/etc/promotions-tool",
 
                     {"Fn::Join":["", ["aws --region ", { "Ref": "AWS::Region" }, " s3 cp s3://gu-promotions-tool-dist/", { "Ref": "Stack" }, "/", { "Ref": "Stage" }, "/", { "Ref": "App" }, "/", "promotions-tool_1.0-SNAPSHOT_all.deb /tmp"]]},
                     "dpkg -i /tmp/promotions-tool_1.0-SNAPSHOT_all.deb",

--- a/cloudformation/memsub-promotions-cf.json
+++ b/cloudformation/memsub-promotions-cf.json
@@ -430,8 +430,8 @@
 
                     "CONF_DIR=/etc/memsub-promotions",
 
-                    {"Fn::Join":["", ["aws --region ", { "Ref": "AWS::Region" }, " s3 cp s3://gu-promotions-tool-dist/", { "Ref": "Stack" }, "/", { "Ref": "Stage" }, "/", { "Ref": "App" }, "/", "memsub-promotions_1.0-SNAPSHOT_all.deb /tmp"]]},
-                    "dpkg -i /tmp/memsub-promotions_1.0-SNAPSHOT_all.deb",
+                    {"Fn::Join":["", ["aws --region ", { "Ref": "AWS::Region" }, " s3 cp s3://gu-promotions-tool-dist/", { "Ref": "Stack" }, "/", { "Ref": "Stage" }, "/", { "Ref": "App" }, "/", "promotions-tool_1.0-SNAPSHOT_all.deb /tmp"]]},
+                    "dpkg -i /tmp/promotions-tool_1.0-SNAPSHOT_all.deb",
 
                     "mkdir -p /etc/gu",
 

--- a/cloudformation/memsub-promotions-cf.json
+++ b/cloudformation/memsub-promotions-cf.json
@@ -436,7 +436,7 @@
                     "mkdir -p /etc/gu",
 
                     {"Fn::Join":["", ["aws --region ", { "Ref": "AWS::Region" }, " s3 cp s3://gu-promotions-tool-private/", { "Ref": "Stage" }, "/memsub-promotions-keys.conf /etc/gu"]]},
-                    "chown memsub-promotions /etc/gu/memsub-promotions-keys.conf",
+                    "chown promotions-tool /etc/gu/memsub-promotions-keys.conf",
                     "chmod 0600 /etc/gu/memsub-promotions-keys.conf",
 
                     "wget https://s3.amazonaws.com/aws-cloudwatch/downloads/latest/awslogs-agent-setup.py",

--- a/cloudformation/memsub-promotions-cf.json
+++ b/cloudformation/memsub-promotions-cf.json
@@ -430,8 +430,8 @@
 
                     "CONF_DIR=/etc/memsub-promotions",
 
-                    {"Fn::Join":["", ["aws --region ", { "Ref": "AWS::Region" }, " s3 cp s3://gu-promotions-tool-dist/", { "Ref": "Stack" }, "/", { "Ref": "Stage" }, "/", { "Ref": "App" }, "/", "promotions-tool_1.0-SNAPSHOT_all.deb /tmp"]]},
-                    "dpkg -i /tmp/promotions-tool_1.0-SNAPSHOT_all.deb",
+                    {"Fn::Join":["", ["aws --region ", { "Ref": "AWS::Region" }, " s3 cp s3://gu-promotions-tool-dist/", { "Ref": "Stack" }, "/", { "Ref": "Stage" }, "/", { "Ref": "App" }, "/", "memsub-promotions_1.0-SNAPSHOT_all.deb /tmp"]]},
+                    "dpkg -i /tmp/memsub-promotions_1.0-SNAPSHOT_all.deb",
 
                     "mkdir -p /etc/gu",
 

--- a/conf/deploy.json
+++ b/conf/deploy.json
@@ -1,22 +1,27 @@
 {
-  "defaultStacks": ["membership"],
+  "defaultStacks": [
+    "membership"
+  ],
   "packages": {
     "ami-update": {
-       "type": "ami-cloudformation-parameter",
-       "apps": [
-         "memsub-promotions"
-       ],
-       "data": {
-         "amiTags": {
-           "Recipe": "xenial-membership",
-           "AmigoStage": "PROD"
-         },
+      "type": "ami-cloudformation-parameter",
+      "apps": [
+        "promotions-tool"
+      ],
+      "data": {
+        "amiTags": {
+          "Recipe": "xenial-membership",
+          "AmigoStage": "PROD"
+        },
         "amiParameter": "AmiId",
         "cloudFormationStackByTags": true
       }
     },
-    "memsub-promotions": {
-      "type":"autoscaling",
+    "promotions-tool": {
+      "type": "autoscaling",
+      "apps": [
+        "promotions-tool"
+      ],
       "data": {
         "port": "9000",
         "bucket": "gu-promotions-tool-dist"
@@ -24,18 +29,21 @@
     }
   },
   "recipes": {
-    "default" : {
-      "depends" : [
+    "default": {
+      "depends": [
         "uploadArtifacts",
         "deploy"
       ]
     },
     "uploadArtifacts": {
-      "actionsBeforeApp": ["ami-update.update","memsub-promotions.uploadArtifacts"]
+      "actionsBeforeApp": [
+        "ami-update.update",
+        "promotions-tool.uploadArtifacts"
+      ]
     },
     "deploy": {
       "actionsPerHost": [
-        "memsub-promotions.deploy"
+        "promotions-tool.deploy"
       ]
     }
   }

--- a/conf/deploy.json
+++ b/conf/deploy.json
@@ -35,7 +35,7 @@
     },
     "deploy": {
       "actionsPerHost": [
-        "promotions-tool.deploy"
+        "memsub-promotions.deploy"
       ]
     }
   }

--- a/conf/deploy.json
+++ b/conf/deploy.json
@@ -31,7 +31,7 @@
       ]
     },
     "uploadArtifacts": {
-      "actionsBeforeApp": ["ami-update.update","promotions-tool.uploadArtifacts"]
+      "actionsBeforeApp": ["ami-update.update","memsub-promotions.uploadArtifacts"]
     },
     "deploy": {
       "actionsPerHost": [

--- a/conf/deploy.json
+++ b/conf/deploy.json
@@ -15,11 +15,8 @@
         "cloudFormationStackByTags": true
       }
     },
-    "promotions-tool": {
+    "memsub-promotions": {
       "type":"autoscaling",
-      "apps": [
-        "promotions-tool"
-      ],
       "data": {
         "port": "9000",
         "bucket": "gu-promotions-tool-dist"

--- a/conf/logback.xml
+++ b/conf/logback.xml
@@ -1,12 +1,12 @@
 <configuration>
 
-  <contextName>memsub-promotions</contextName>
+  <contextName>promotions-tool</contextName>
 
   <appender name="LOGFILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
-    <file>logs/memsub-promotions.log</file>
+    <file>logs/promotions-tool.log</file>
 
     <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
-      <fileNamePattern>logs/memsub-promotions.log.%d{yyyy-MM-dd}.gz</fileNamePattern>
+      <fileNamePattern>logs/promotions-tool.log.%d{yyyy-MM-dd}.gz</fileNamePattern>
       <maxHistory>30</maxHistory>
     </rollingPolicy>
 

--- a/conf/logger.conf
+++ b/conf/logger.conf
@@ -1,8 +1,8 @@
 [general]
 state_file = /var/awslogs/agent-state
 
-[memsub-promotions]
-file = /var/log/memsub-promotions/memsub-promotions.log
+[promotions-tool]
+file = /var/log/promotions-tool/promotions-tool.log
 log_group_name = MemsubPromotions-__STAGE
 log_stream_name = __DATE/__BUILD/{instance_id}/memsub-promotions.log
 datetime_format = %Y-%m-%d %H:%M-%S

--- a/conf/logger.conf
+++ b/conf/logger.conf
@@ -2,7 +2,7 @@
 state_file = /var/awslogs/agent-state
 
 [memsub-promotions]
-file = var/log/memsub-promotions/memsub-promotions.log
+file = /var/log/memsub-promotions/memsub-promotions.log
 log_group_name = MemsubPromotions-__STAGE
 log_stream_name = __DATE/__BUILD/{instance_id}/memsub-promotions.log
 datetime_format = %Y-%m-%d %H:%M-%S


### PR DESCRIPTION
In [PR 103](https://github.com/guardian/memsub-promotions/pull/103), I accidentally made it so that when an artifact is generated in this app, it's in a folder called 'memsub-promotions' while riff-raff expects to find an artifact for an app 'promotions-tool'.

So let it be promotions-tool. 