### PR TITLE
Reconstruct a PromoCode-View table from a Promotions table

### DIFF
--- a/cloudformation/memsub-promotions-cf.yaml
+++ b/cloudformation/memsub-promotions-cf.yaml
@@ -145,6 +145,7 @@ Resources:
           - Effect: Allow
             Action:
             - dynamodb:BatchWriteItem
+            - dynamodb:PutItem
             - dynamodb:Scan
             Resource: !FindInMap [StageVariables, !Ref 'Stage', DynamoDBTableViews]
           - Effect: Allow

--- a/lambdas/src/MembershipSub-PromoCode-View-Dynamo-to-Data-Lake.js
+++ b/lambdas/src/MembershipSub-PromoCode-View-Dynamo-to-Data-Lake.js
@@ -1,30 +1,34 @@
+'use strict';
+
+const AWS = require('aws-sdk');
+const DOC = require('dynamodb-doc');
+
+const ddb = new AWS.DynamoDB();
+const docClient = new DOC.DynamoDB(ddb);
+const s3 = new AWS.S3();
+
 function enquote(anArray) {
     return `"${anArray.join('","')}"`;
 }
 
 exports.handler = (event, context, callback) => {
 
-    var AWS = require('aws-sdk');
-    AWS.config.update({region: 'eu-west-1'});
-    var ddb = new AWS.DynamoDB();
-    var s3 = new AWS.S3();
-
-    const source = /PROD$/.test(context.functionName) ? 'PROD' : 'TEST';
+    const source = /PROD$/.test(context.functionName) ? 'PROD' : 'UAT';
     const TableName = `MembershipSub-PromoCode-View-${source}`;
     const Bucket = 'ophan-raw-membership-promo-code-view';
     const Key = TableName + '.csv';
-    const fieldsToExport = ['promo_code', 'promotion_name', 'campaign_name', 'channel_name', 'product_family'];
+    const fieldsToExport = ['promo_code', 'promotion_name', 'campaign_name', 'channel_name', 'product_family', 'promotion_type', 'discount_percent', 'discount_months'];
+    const ACL = 'bucket-owner-full-control';
 
-    ddb.scan({ TableName }, (err, data) => {
-        if (err) return callback(err);
-
-        const CSVData = [enquote(fieldsToExport)].concat(data.Items.map(record => enquote(fieldsToExport.map(field => record[field].S))));
-
-        s3.putObject({
-            Bucket, Key,
-            ACL: 'bucket-owner-full-control',
-            Body: CSVData.join('\n')
-        }, (err2, data2) => callback(err2, `Successfully exported ${CSVData.length} records from ${TableName} to aws-ophan S3 file: s3://${Bucket}/${Key} (RAW Data Lake)`));
-    });
+    docClient.scan({ TableName })
+    .promise()
+    .then(data => {
+        const CSVData = [enquote(fieldsToExport)].concat(data.Items.map(record => enquote(fieldsToExport.map(field => record[field]))));
+        const Body = CSVData.join('\n');
+        s3.putObject({ Bucket, Key, ACL, Body}, (err2, _) => {
+            callback(err2, `Successfully exported ${CSVData.length} records from ${TableName} to aws-ophan S3 file: s3://${Bucket}/${Key} (RAW Data Lake)`)
+        });
+    })
+    .catch(callback);
 
 };

--- a/lambdas/src/MembershipSub-Promotions-to-PromoCode-View-Lambda.js
+++ b/lambdas/src/MembershipSub-Promotions-to-PromoCode-View-Lambda.js
@@ -1,19 +1,21 @@
 'use strict';
 
-var AWS = require('aws-sdk'),
-    DOC = require('dynamodb-doc');
-var docClient = new DOC.DynamoDB();
-var TOUCHPOINT_BACKEND = 'UAT';
-var campaignDetailsByCampaignCode = {};
-var putRequestsByPromoCode = {};
-var promoCodesToUpdate = [];
+const AWS = require('aws-sdk');
+const DOC = require('dynamodb-doc');
+
+const ddb = new AWS.DynamoDB();
+const docClient = new DOC.DynamoDB(ddb);
+const campaignDetailsByCampaignCode = {};
+const putRequestsByPromoCode = {};
+
+let promoCodesToUpdate = [];
 
 function handleEventRecords(eventRecords) {
     if (!(eventRecords && eventRecords.length > 0)) { return; }
 
     eventRecords.forEach((record) => {
         if (!record.dynamodb) { return; }
-        var newImage = record.dynamodb.NewImage;
+        let newImage = record.dynamodb.NewImage;
 
         Object.keys(newImage.codes.M)
         .forEach((channelName) => {
@@ -27,14 +29,23 @@ function handleEventRecords(eventRecords) {
 function generatePutRequestFromDynamoPromoCodeObject(promoCodeObj, newImage, channelName) {
     if (!(promoCodeObj && newImage.campaignCode && newImage.name)) { return; }
 
-    var promoCode = promoCodeObj.S;
+    const promoCode = promoCodeObj.S;
     if (!promoCode) { return; }
-    var campaignCode = newImage.campaignCode.S;
-    var promotionName = newImage.name.S;
+    const campaignCode = newImage.campaignCode.S;
+    const promotionName = newImage.name.S;
     if (!promotionName) { return; }
     if (!campaignCode) { return; }
-    var campaignData = campaignDetailsByCampaignCode[campaignCode];
+    const campaignData = campaignDetailsByCampaignCode[campaignCode];
     if (!campaignData) { return; }
+    const promotionType = newImage.promotionType;
+    if (!(promotionType && promotionType.M && promotionType.M.name)) { return; }
+    const promotionTypeName = promotionType.M.name.S;
+    let discountPercent = 0;
+    let discountDurationMonths = 0;
+    if (promotionTypeName === 'percent_discount') {
+        discountPercent = parseInt(promotionType.M.amount.N, 10);
+        discountDurationMonths = parseInt(promotionType.M.durationMonths.N, 10);
+    }
 
     putRequestsByPromoCode[promoCode] = {
         PutRequest: {
@@ -44,40 +55,44 @@ function generatePutRequestFromDynamoPromoCodeObject(promoCodeObj, newImage, cha
                 campaign_code: campaignCode,
                 promotion_name: promotionName,
                 campaign_name: campaignData.campaign_name,
-                product_family: campaignData.product_family
+                product_family: campaignData.product_family,
+                promotion_type: promotionTypeName,
+                discount_percent: discountPercent,
+                discount_months: discountDurationMonths
             }
         }
     };
 }
 
-function chunkedUpdateOfPromoCodes(callback) {
-    var i, j, temparray, chunk = 25;
+function chunkedUpdateOfPromoCodes(callback, TOUCHPOINT_BACKEND) {
+    let i, j, temparray = [];
+    const chunk = 25;
 
     promoCodesToUpdate = Object.keys(putRequestsByPromoCode);
 
     for (i = 0, j = promoCodesToUpdate.length; i < j; i += chunk) {
         temparray = promoCodesToUpdate.slice(i, i + chunk);
         if (!temparray || temparray.length === 0) continue;
-        batchWriteRequestsForCodes(temparray, callback);
+        batchWriteRequestsForCodes(temparray, callback, TOUCHPOINT_BACKEND);
     }
 }
 
-function batchWriteRequestsForCodes(promoCodes, callback) {
-    var putRequestsAsArray = [];
+function batchWriteRequestsForCodes(promoCodes, callback, TOUCHPOINT_BACKEND) {
+    const putRequestsAsArray = [];
 
     promoCodes.forEach((key) => putRequestsAsArray.push(putRequestsByPromoCode[key]));
 
-    console.log(`Putting records into table: MembershipSub-PromoCode-View-${TOUCHPOINT_BACKEND} = `, JSON.stringify(putRequestsAsArray, true));
+    console.log(`Putting records into table: MembershipSub-PromoCode-View-${TOUCHPOINT_BACKEND} = `, JSON.stringify(putRequestsAsArray));
 
-    var RequestItemsObj = {};
+    const RequestItemsObj = {};
     RequestItemsObj['MembershipSub-PromoCode-View-' + TOUCHPOINT_BACKEND] = putRequestsAsArray;
 
     docClient.batchWriteItem({
         RequestItems: RequestItemsObj
     })
     .promise()
-    .then((data) => {
-            promoCodes.forEach((key) => delete putRequestsByPromoCode[key]);
+    .then(_ => {
+        promoCodes.forEach((key) => delete putRequestsByPromoCode[key]);
         console.log(`Updated ${putRequestsAsArray.length} of ${promoCodesToUpdate.length} promo code views.`);
         attemptToComplete(callback);
     })
@@ -91,14 +106,11 @@ function attemptToComplete(callback) {
     if (Object.keys(putRequestsByPromoCode).length > 0) { return; }
 
     callback(null, `Updated all ${promoCodesToUpdate.length} promo code views.`);
-
-    // Not needed in node 4.3 EV
-    // context.done('success', promoCodesToUpdate.length);
 }
 
 exports.handler = (event, context, callback) => {
 
-    TOUCHPOINT_BACKEND = /PROD$/.test(context.functionName) ? 'PROD' : 'UAT';
+    const TOUCHPOINT_BACKEND = /PROD$/.test(context.functionName) ? 'PROD' : 'UAT';
 
     docClient.scan({
         TableName: 'MembershipSub-Campaigns-' + TOUCHPOINT_BACKEND
@@ -115,7 +127,7 @@ exports.handler = (event, context, callback) => {
 
         handleEventRecords(event.Records);
 
-        chunkedUpdateOfPromoCodes(callback);
+        chunkedUpdateOfPromoCodes(callback, TOUCHPOINT_BACKEND);
 
         attemptToComplete(callback);
     })

--- a/lambdas/src/MembershipSub-Reconstruct-PromoCode-View.js
+++ b/lambdas/src/MembershipSub-Reconstruct-PromoCode-View.js
@@ -1,0 +1,135 @@
+'use strict';
+
+const fs = require('fs');
+const AWS = require('aws-sdk');
+
+Array.prototype.flatMap = function(lambda) {
+    return Array.prototype.concat.apply([], this.map(lambda));
+};
+
+function generatePutRequest(campaignsByCode, channelName, promotion, tableName) {
+    return (promoCodeObj) => {
+        const campaignCode = promotion.campaignCode.S;
+        const promotionName = promotion.name.S;
+        if (!promotionName) {
+            return;
+        }
+        if (!campaignCode) {
+            return;
+        }
+        const campaignData = campaignsByCode[campaignCode];
+        if (!campaignData) {
+            return;
+        }
+        const promotionType = promotion.promotionType;
+        if (!(promotionType && promotionType.M && promotionType.M.name)) {
+            return;
+        }
+        const promotionTypeName = promotionType.M.name.S;
+        let discountPercent = 0;
+        let discountDurationMonths = 0;
+        if (promotionTypeName === 'percent_discount') {
+            if (promotionType.M.amount) {
+                discountPercent = parseInt(promotionType.M.amount.N, 10);
+            }
+            if (promotionType.M.durationMonths) {
+                discountDurationMonths = parseInt(promotionType.M.durationMonths.N, 10);
+            }
+        }
+
+        const promoCode = promoCodeObj.S;
+        if (!promoCode) {
+            return;
+        }
+
+        return {
+            TableName: tableName,
+            Item: {
+                channel_name: channelName,
+                promo_code: promoCode,
+                campaign_code: campaignCode,
+                promotion_name: promotionName,
+                campaign_name: campaignData.campaign_name,
+                product_family: campaignData.product_family,
+                promotion_type: promotionTypeName,
+                discount_percent: discountPercent,
+                discount_months: discountDurationMonths
+            }
+        };
+    };
+}
+
+function generatePutRequests(campaignsByCode, promotions, tableName) {
+    return promotions.flatMap(promotion => {
+        const codesObj = promotion.codes.M;
+        const channelNames = Object.keys(codesObj);
+        return channelNames.flatMap(channelName => {
+            const promoCodes =  codesObj[channelName].L;
+            return promoCodes.map(generatePutRequest(campaignsByCode, channelName, promotion, tableName));
+        });
+    });
+}
+
+function collateCampaigns(campaigns) {
+    const campaignDetailsByCampaignCode = {};
+    campaigns.forEach(campaign => {
+        campaignDetailsByCampaignCode[campaign.code.S] = {
+            campaign_name: campaign.name.S,
+            product_family: (campaign.group || campaign.productFamily).S // legacy
+        }
+    });
+    return campaignDetailsByCampaignCode;
+}
+
+function rapidWritePutRequestsIntoTable(putRequests) {
+    const DOC = require('dynamodb-doc');
+    const docClient = new DOC.DynamoDB();
+
+    console.log(`Attempting to update ${putRequests.length} promo code views`);
+
+    const promises = putRequests.map(putRequest => docClient.putItem(putRequest).promise());
+
+    return Promise.all(promises).then(responses => {
+        console.log(`Updated ${responses.length} promo code views`)
+    });
+}
+
+
+exports.local = (event, context, callback) => {
+    // lambda-local -l MembershipSub-Reconstruct-PromoCode-View.js -h local -e examples/local.js
+
+    fs.statSync('campaigns.json');
+    fs.statSync('promotions.json');
+
+    const campaigns = fs.readFileSync('campaigns.json', { encoding: 'UTF-8' }).trim().split('\n').map(JSON.parse);
+    const campaignsByCode = collateCampaigns(campaigns);
+    const promotions = fs.readFileSync('promotions.json', { encoding: 'UTF-8' }).trim().split('\n').map(JSON.parse);
+    const putRequests = generatePutRequests(campaignsByCode, promotions, event.tableToUpdate);
+    if (event.tableToUpdate) {
+        rapidWritePutRequestsIntoTable(putRequests).then(callback);
+    } else {
+        callback(null, putRequests);
+    }
+};
+
+exports.handler = (event, context, callback) => {
+    const ddb = new AWS.DynamoDB();
+
+    const source = /PROD$/.test(context.functionName) ? 'PROD' : 'UAT';
+
+    const campaignsP = ddb.scan({ TableName: `MembershipSub-Campaigns-${source}`}).promise();
+    const promotionsP = ddb.scan({ TableName: `MembershipSub-Promotions-${source}`}).promise();
+
+    campaignsP.then(campaigns => {
+        return promotionsP.then(promotions => {
+            console.log(`Got ${campaigns.Items.length} campaigns and ${promotions.Items.length} promotions from raw data sources`);
+            const putRequests = generatePutRequests(collateCampaigns(campaigns.Items), promotions.Items, `MembershipSub-PromoCode-View-TEST`);
+            const validatedPutRequests = putRequests.filter(putRequest => !!(putRequest && putRequest.Item));
+            console.log(`Created ${putRequests.length} PutRequets. ${validatedPutRequests.length} are valid`);
+            return validatedPutRequests;
+        })
+    })
+        .then(rapidWritePutRequestsIntoTable)
+        .then(callback)
+        .catch(callback);
+};

--- a/lambdas/src/examples/local.js
+++ b/lambdas/src/examples/local.js
@@ -1,0 +1,4 @@
+// Sample event data
+module.exports = {
+    xtableToUpdate: "MembershipSub-PromoCode-View-TEST"
+};


### PR DESCRIPTION
I've added a new lambda function to this project which can be manually provisioned whenever we want to fully reconstruct a MembershipSub-PromoCode-View-[STAGE] DynamoDB table. Providing the Lambda has PROD or UAT in its name it will reconstruct the relevant STAGE table.

I've also done some cosmetic changes to a few of the other Lambdas to keep the JavaScript up-to-date as they've moved execution from node 4.3 to 6.10. I've avoided non-standard libraries and any build systems deliberately to make changing and testing them locally them more accessible.

This PR will also be used to test all deployment pipelines again before handing over Product responsibility from SX to Acquisitions/S&C.

cc @davidfurey @jacobwinch @pvighi @lmath 