### PR TITLE
Removed the security group giving us SSH access to the box, using instance group instead

### DIFF
--- a/cloudformation/memsub-promotions-cf.yaml
+++ b/cloudformation/memsub-promotions-cf.yaml
@@ -171,7 +171,6 @@ Resources:
       ImageId: !Ref 'AmiId'
       SecurityGroups:
       - !Ref 'InstanceSecurityGroup'
-      - !Ref 'SshAccessSecurityGroup'
       - !Ref 'VulnerabilityScanningSecurityGroup'
       InstanceType: !Ref 'InstanceType'
       AssociatePublicIpAddress: 'True'
@@ -196,21 +195,11 @@ Resources:
               systemctl enable awslogs
               systemctl start awslogs
             - {}
-  SshAccessSecurityGroup:
-    Type: AWS::EC2::SecurityGroup
-    Properties:
-      VpcId: !Ref 'VpcId'
-      GroupDescription: Open up SSH access
-      SecurityGroupIngress:
-      - IpProtocol: tcp
-        FromPort: '22'
-        ToPort: '22'
-        CidrIp: !Ref 'InternalCidrIp'
   LoadBalancerSecurityGroup:
     Type: AWS::EC2::SecurityGroup
     Properties:
       VpcId: !Ref 'VpcId'
-      GroupDescription: Open up HTTP  access to load balancer
+      GroupDescription: Open up HTTPS access to load balancer
       SecurityGroupIngress:
       - IpProtocol: tcp
         FromPort: '443'
@@ -225,8 +214,12 @@ Resources:
     Type: AWS::EC2::SecurityGroup
     Properties:
       VpcId: !Ref 'VpcId'
-      GroupDescription: Open up HTTP access to load balancer
+      GroupDescription: Open up HTTP access to load balancer, SSH to office
       SecurityGroupIngress:
+      - IpProtocol: tcp
+        FromPort: '22'
+        ToPort: '22'
+        CidrIp: !Ref 'InternalCidrIp'
       - IpProtocol: tcp
         FromPort: '9000'
         ToPort: '9000'


### PR DESCRIPTION
Removed the security group giving us SSH access to the box and instead attached the ingress rule to the instance's security group. This was because the default if no egress rule is selected is to open up a rule allowing outbound access to all ports and IP protocols to any location. See 'Remove Default Rule': https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-security-group.html

See the same change done on [Members Data API](https://github.com/guardian/members-data-api/pull/318).

cc @davidfurey @johnduffell  
