### PR TITLE
Grant access to specific file in another bucket

### DIFF
--- a/cloudformation/memsub-promotions-cf.yaml
+++ b/cloudformation/memsub-promotions-cf.yaml
@@ -81,6 +81,9 @@ Resources:
             Action: s3:GetObject
             Resource: 'arn:aws:s3:::gu-promotions-tool-dist/*'
           - Effect: Allow
+            Action: s3:GetObject
+            Resource: 'arn:aws:s3:::membership-private/membership_directory_cert.p12'
+          - Effect: Allow
             Action: ec2:DescribeTags
             Resource: '*'
           - Effect: Allow


### PR DESCRIPTION
This file is used [here](https://github.com/guardian/memsub-common-play-auth/blob/8ed99f375a03107f2e44faa34bbb8ccfc834dc04/src/main/scala/com/gu/memsub/auth/common/MemSub.scala#L21).

Access to this file would have been removed [by this change](https://github.com/guardian/memsub-promotions/pull/111/files#diff-2dd880e34d862e0c46ed1ba4bf03aa0eL270), had we not [recently added](https://github.com/guardian/memsub-promotions/pull/109/files#diff-2dd880e34d862e0c46ed1ba4bf03aa0eR277) the AmazonEC2RoleforSSM, which was granting access to all S3 buckets. So when I removed that role [here](https://github.com/guardian/memsub-promotions/pull/114/files#diff-2dd880e34d862e0c46ed1ba4bf03aa0eL110), things broke in a fairly unpredictable way! Something to be cautious of when we remove that role from other apps...