### PR TITLE
Tighten up S3 permissions

### DIFF
--- a/cloudformation/memsub-promotions-cf.yaml
+++ b/cloudformation/memsub-promotions-cf.yaml
@@ -57,6 +57,12 @@ Parameters:
     Description: Security group that grants access to the account's Vulnerability
       Scanner
     Type: AWS::EC2::SecurityGroup::Id
+  ReadableS3Resources:
+    Description: List of S3 resources that this app should be allowed to read
+    Type: CommaDelimitedList
+    AllowedValues:
+    - arn:aws:s3:::gu-reader-revenue-private/membership/promotions-tool/PROD/*,arn:aws:s3:::gu-promotions-tool-dist/*,arn:aws:s3:::membership-private/membership_directory_cert.p12
+    - arn:aws:s3:::gu-reader-revenue-private/membership/promotions-tool/CODE/*,arn:aws:s3:::gu-promotions-tool-dist/*,arn:aws:s3:::membership-private/membership_directory_cert.p12
 Resources:
   ServerRole:
     Type: AWS::IAM::Role
@@ -74,15 +80,12 @@ Resources:
       - PolicyName: root
         PolicyDocument:
           Statement:
+          - Effect: Deny # Explicitly deny access to all S3 resources except for those defined in ReadableS3Resources
+            Action: s3:*
+            NotResource: !Ref ReadableS3Resources
           - Effect: Allow
             Action: s3:GetObject
-            Resource: !Sub arn:aws:s3:::gu-reader-revenue-private/${Stack}/${App}/${Stage}/*
-          - Effect: Allow
-            Action: s3:GetObject
-            Resource: 'arn:aws:s3:::gu-promotions-tool-dist/*'
-          - Effect: Allow
-            Action: s3:GetObject
-            Resource: 'arn:aws:s3:::membership-private/membership_directory_cert.p12'
+            Resource: !Ref ReadableS3Resources
           - Effect: Allow
             Action: ec2:DescribeTags
             Resource: '*'

--- a/cloudformation/memsub-promotions-cf.yaml
+++ b/cloudformation/memsub-promotions-cf.yaml
@@ -81,6 +81,9 @@ Resources:
             Action: s3:GetObject
             Resource: 'arn:aws:s3:::gu-promotions-tool-dist/*'
           - Effect: Allow
+            Action: s3:GetObject
+            Resource: 'arn:aws:s3:::membership-private/membership_directory_cert.p12'
+          - Effect: Allow
             Action: ec2:DescribeTags
             Resource: '*'
           - Effect: Allow

--- a/cloudformation/memsub-promotions-cf.yaml
+++ b/cloudformation/memsub-promotions-cf.yaml
@@ -57,12 +57,20 @@ Parameters:
     Description: Security group that grants access to the account's Vulnerability
       Scanner
     Type: AWS::EC2::SecurityGroup::Id
-  ReadableS3Resources:
-    Description: List of S3 resources that this app should be allowed to read
-    Type: CommaDelimitedList
-    AllowedValues:
-    - arn:aws:s3:::gu-reader-revenue-private/membership/promotions-tool/PROD/*,arn:aws:s3:::gu-promotions-tool-dist/*,arn:aws:s3:::membership-private/membership_directory_cert.p12
-    - arn:aws:s3:::gu-reader-revenue-private/membership/promotions-tool/CODE/*,arn:aws:s3:::gu-promotions-tool-dist/*,arn:aws:s3:::membership-private/membership_directory_cert.p12
+
+Mappings:
+    StageMap:
+      CODE:
+        ReadableS3Resources:
+          - arn:aws:s3:::gu-reader-revenue-private/membership/promotions-tool/CODE/*
+          - arn:aws:s3:::gu-promotions-tool-dist/*
+          - arn:aws:s3:::membership-private/membership_directory_cert.p12
+      PROD:
+        ReadableS3Resources:
+          - arn:aws:s3:::gu-reader-revenue-private/membership/promotions-tool/PROD/*
+          - arn:aws:s3:::gu-promotions-tool-dist/*
+          - arn:aws:s3:::membership-private/membership_directory_cert.p12
+
 Resources:
   ServerRole:
     Type: AWS::IAM::Role
@@ -82,10 +90,10 @@ Resources:
           Statement:
           - Effect: Deny # Explicitly deny access to all S3 resources except for those defined in ReadableS3Resources
             Action: s3:*
-            NotResource: !Ref ReadableS3Resources
+            NotResource: !FindInMap [StageMap, !Ref Stage, ReadableS3Resources]
           - Effect: Allow
             Action: s3:GetObject
-            Resource: !Ref ReadableS3Resources
+            Resource: !FindInMap [StageMap, !Ref Stage, ReadableS3Resources]
           - Effect: Allow
             Action: ec2:DescribeTags
             Resource: '*'

--- a/cloudformation/memsub-promotions-cf.yaml
+++ b/cloudformation/memsub-promotions-cf.yaml
@@ -88,7 +88,9 @@ Resources:
       - PolicyName: root
         PolicyDocument:
           Statement:
-          - Effect: Deny # Explicitly deny access to all S3 resources except for those defined in ReadableS3Resources
+          # Explicitly deny access to all S3 resources except for those defined in ReadableS3Resources
+          # https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_evaluation-logic.html#policy-eval-denyallow
+          - Effect: Deny
             Action: s3:*
             NotResource: !FindInMap [StageMap, !Ref Stage, ReadableS3Resources]
           - Effect: Allow


### PR DESCRIPTION
Previously introducing an 'Allow' statement with a wide scope rendered an Allow statement with a more limited scope redundant, although this is not easy to spot when reviewing Cloudformation changes or applying changes (see https://github.com/guardian/memsub-promotions/pull/115).

This PR explicitly denies access to all S3 resources except for those defined in the ReadableS3Resources parameter, which means that inadvertently pulling in a statement with wide scope (e.g. by attaching a managed policy which allows access to all S3 resources) will no longer have these unintended consequences.

See also: https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_evaluation-logic.html#policy-eval-denyallow


