### PR TITLE
Upgrade libs - Snyk

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -56,6 +56,7 @@ libraryDependencies ++= Seq(
   "com.softwaremill.macwire" %% "util" % "2.2.2",
   "com.softwaremill.macwire" %% "proxy" % "2.2.2",
   "io.netty" % "netty" % "3.10.3.Final",
+  "ch.qos.logback" % "logback-classic" % "1.2.3",
   "org.scalatestplus.play" %% "scalatestplus-play" % "1.5.1" % Test
 )
 

--- a/build.sbt
+++ b/build.sbt
@@ -51,12 +51,13 @@ libraryDependencies ++= Seq(
   ws,
   "org.scalaz" %% "scalaz-core" % "7.1.3",
   "com.gu" %% "membership-common" % "0.379",
-  "com.gu" %% "memsub-common-play-auth" % "0.9",
+  "com.gu" %% "memsub-common-play-auth" % "0.7",
   "com.softwaremill.macwire" %% "macros" % "2.2.2" % "provided",
   "com.softwaremill.macwire" %% "util" % "2.2.2",
   "com.softwaremill.macwire" %% "proxy" % "2.2.2",
   "com.fasterxml.jackson.core" % "jackson-databind" % "2.8.11.1",
   "io.netty" % "netty" % "3.10.3.Final",
+  "ch.qos.logback" % "logback-core" % "1.2.0",
   "org.scalatestplus.play" %% "scalatestplus-play" % "1.5.1" % Test
 )
 

--- a/build.sbt
+++ b/build.sbt
@@ -51,10 +51,12 @@ libraryDependencies ++= Seq(
   ws,
   "org.scalaz" %% "scalaz-core" % "7.1.3",
   "com.gu" %% "membership-common" % "0.379",
-  "com.gu" %% "memsub-common-play-auth" % "0.7",
+  "com.gu" %% "memsub-common-play-auth" % "0.9",
   "com.softwaremill.macwire" %% "macros" % "2.2.2" % "provided",
   "com.softwaremill.macwire" %% "util" % "2.2.2",
   "com.softwaremill.macwire" %% "proxy" % "2.2.2",
+  "com.fasterxml.jackson.core" % "jackson-databind" % "2.8.11.1",
+  "io.netty" % "netty" % "3.10.3.Final",
   "org.scalatestplus.play" %% "scalatestplus-play" % "1.5.1" % Test
 )
 

--- a/build.sbt
+++ b/build.sbt
@@ -57,7 +57,7 @@ libraryDependencies ++= Seq(
   "com.softwaremill.macwire" %% "proxy" % "2.2.2",
   "com.fasterxml.jackson.core" % "jackson-databind" % "2.8.11.1",
   "io.netty" % "netty" % "3.10.3.Final",
-  "ch.qos.logback" % "logback-core" % "1.2.0",
+  "ch.qos.logback" % "logback-classic" % "1.2.0",
   "org.scalatestplus.play" %% "scalatestplus-play" % "1.5.1" % Test
 )
 

--- a/build.sbt
+++ b/build.sbt
@@ -55,9 +55,7 @@ libraryDependencies ++= Seq(
   "com.softwaremill.macwire" %% "macros" % "2.2.2" % "provided",
   "com.softwaremill.macwire" %% "util" % "2.2.2",
   "com.softwaremill.macwire" %% "proxy" % "2.2.2",
-  "com.fasterxml.jackson.core" % "jackson-databind" % "2.8.11.1",
   "io.netty" % "netty" % "3.10.3.Final",
-  "ch.qos.logback" % "logback-classic" % "1.2.0",
   "org.scalatestplus.play" %% "scalatestplus-play" % "1.5.1" % Test
 )
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -23,4 +23,6 @@ addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.1.6")
 
 addSbtPlugin("com.gu" % "sbt-riffraff-artifact" % "0.9.7")
 
+addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.9.0")
+
 libraryDependencies += "org.vafer" % "jdeb" % "1.3" artifacts (Artifact("jdeb", "jar", "jar"))

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,5 @@
 // The Play plugin
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.5.2")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.5.14")
 
 // web plugins
 


### PR DESCRIPTION
**1. logback-classic - logback-core** - SOLVED
Vulnerable module: ch.qos.logback:logback-classic [CVE-2017-5929] - Logback before 1.2.0 has a serialization vulnerability affecting the SocketServer and ServerSocketReceiver components

**2. xerces:xercesImpl** - UPDATE NOT POSSIBLE
Vulnerable module: xerces:xercesImpl [CVE-2017-10355] - **MODIFIED**
This vulnerability has been modified since it was last analyzed by the NVD. It is awaiting reanalysis which may result in further changes to the information provided.

**3. jackson-databind** - UPDATE NOT POSSIBLE
https://github.com/guardian/zuora-auto-cancel/pull/65

**4. io.netty:netty** - SOLVED
Vulnerable module: io.netty:netty [CVE-2015-2156] - Upgrade io.netty:netty to version 3.9.8.Final, 3.10.3.Final, 4.0.28.Final, 4.1.0.Beta5 or higher.

**5. LGPL-3.0 license** - UPDATE NOT POSSIBLE