### PR TITLE
Update Guardian libraries in preparation for catalog loading changes

### DIFF
--- a/app/actions/GoogleAuthAction.scala
+++ b/app/actions/GoogleAuthAction.scala
@@ -5,15 +5,21 @@ import com.gu.googleauth
 import com.gu.memsub.auth.common.MemSub.Google._
 import com.typesafe.config.Config
 import controllers.routes
+import play.api.libs.ws.WSClient
 import play.api.mvc.ActionBuilder
 import play.api.mvc.Security.AuthenticatedRequest
 
 import scala.concurrent.ExecutionContext
 
-class GoogleAuthAction(config: Config)(implicit ec: ExecutionContext) extends googleauth.Actions with googleauth.Filters {
+class GoogleAuthAction(config: Config, ws: WSClient)(implicit ec: ExecutionContext) extends googleauth.Actions with googleauth.Filters {
+
+  implicit def wsClient: WSClient = ws
 
   val authConfig = googleAuthConfigFor(config)
   val loginTarget = routes.AuthController.loginAction()
+  val defaultRedirectTarget = routes.StaticController.index
+  val failureRedirectTarget = routes.AuthController.loginAction()
+
   lazy val groupChecker = googleGroupCheckerFor(config)
 
   val GoogleAuthAction: ActionBuilder[GoogleAuthRequest] = AuthAction andThen requireGroup[GoogleAuthRequest](Set(

--- a/app/controllers/AuthController.scala
+++ b/app/controllers/AuthController.scala
@@ -2,15 +2,13 @@ package controllers
 import com.gu.googleauth.{GoogleAuth, UserIdentity}
 import com.gu.memsub.auth.common.MemSub.Google._
 import com.typesafe.config.Config
-import play.api.Application
 import play.api.libs.json.Json
-import play.api.libs.ws.WSAPI
+import play.api.libs.ws.WSClient
 import play.api.mvc._
-
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 
-class AuthController(config: Config, ws: WSAPI) extends Controller {
+class AuthController(config: Config, implicit val ws: WSClient) extends Controller {
 
   val googleAuthConfig = googleAuthConfigFor(config)
   val ANTI_FORGERY_KEY = "antiForgeryToken"
@@ -20,7 +18,7 @@ class AuthController(config: Config, ws: WSAPI) extends Controller {
     */
   def loginAction = Action.async { implicit request =>
     val antiForgeryToken = GoogleAuth.generateAntiForgeryToken()
-    GoogleAuth.redirectToGoogle(googleAuthConfig, antiForgeryToken, ws)
+    GoogleAuth.redirectToGoogle(googleAuthConfig, antiForgeryToken)
       .map(_.withSession(request.session + (ANTI_FORGERY_KEY -> antiForgeryToken)))
   }
 
@@ -35,7 +33,7 @@ class AuthController(config: Config, ws: WSAPI) extends Controller {
       case None =>
         Future.successful(Unauthorized("No anti forgery token"))
       case Some(token) =>
-        GoogleAuth.validatedUserIdentity(googleAuthConfig, token, ws).map { identity =>
+        GoogleAuth.validatedUserIdentity(googleAuthConfig, token).map { identity =>
           val redirect = Redirect(routes.StaticController.index())
           redirect.withSession { session + (UserIdentity.KEY -> Json.toJson(identity).toString) - ANTI_FORGERY_KEY }
         } recover { case e => Unauthorized(e.toString) }

--- a/app/controllers/PromotionController.scala
+++ b/app/controllers/PromotionController.scala
@@ -9,12 +9,10 @@ import com.gu.memsub.promo.Promotion.AnyPromotion
 import com.gu.memsub.promo._
 import com.gu.memsub.services.JsonDynamoService
 import org.joda.time.DateTimeZone
-import play.api.data.validation.ValidationError
 import play.api.libs.concurrent.Execution.Implicits._
-import play.api.libs.json.{JsError, JsPath, Json}
+import play.api.libs.json.{JsError, JsPath, Json, JsonValidationError}
 import play.api.mvc.Result
 import play.api.mvc.Results._
-
 import scala.concurrent.Future
 import scala.util.Try
 
@@ -48,7 +46,7 @@ class PromotionController(googleAuthAction: GoogleAuthenticatedAction, service: 
 
   def validate = googleAuthAction { request =>
     (for {
-      jsonToTest <- request.body.asJson.toRight[Seq[(JsPath, Seq[ValidationError])]](Seq.empty).right
+      jsonToTest <- request.body.asJson.toRight[Seq[(JsPath, Seq[JsonValidationError])]](Seq.empty).right
       promo <- Json.fromJson[AnyPromotion](jsonToTest).asEither.right
     } yield promo).fold(e => Ok(JsError.toJson(e)), p => Ok(Json.obj("status" -> "ok")))
   }

--- a/build.sbt
+++ b/build.sbt
@@ -49,9 +49,9 @@ libraryDependencies ++= Seq(
   jdbc,
   cache,
   ws,
-  "org.scalaz" %% "scalaz-core" % "7.1.3",
-  "com.gu" %% "membership-common" % "0.379",
-  "com.gu" %% "memsub-common-play-auth" % "0.7",
+  "org.scalaz" %% "scalaz-core" % "7.2.7",
+  "com.gu" %% "membership-common" % "0.515",
+  "com.gu" %% "memsub-common-play-auth" % "1.2",
   "com.softwaremill.macwire" %% "macros" % "2.2.2" % "provided",
   "com.softwaremill.macwire" %% "util" % "2.2.2",
   "com.softwaremill.macwire" %% "proxy" % "2.2.2",
@@ -59,9 +59,6 @@ libraryDependencies ++= Seq(
   "ch.qos.logback" % "logback-classic" % "1.2.3",
   "org.scalatestplus.play" %% "scalatestplus-play" % "1.5.1" % Test
 )
-
-// membership-common has macros compiled against play-json 2.4.6...
-dependencyOverrides += "com.typesafe.play" %% "play-json" % "2.4.6"
 
 resolvers ++= Seq(
   "Guardian Github Releases" at "https://guardian.github.io/maven/repo-releases",


### PR DESCRIPTION
Similar to the work started here (https://github.com/guardian/memsub-promotions/pull/118/files), but with a slightly different motivation...

I want to use the latest membership-common so that I can make changes to the CatalogService.

There are no tests in this project, so I've manually tested GoogleAuth, creating a campaign, and creating a promo code.