### PR TITLE
Load the catalog from s3

### DIFF
--- a/app/conf/CatalogService.scala
+++ b/app/conf/CatalogService.scala
@@ -2,20 +2,21 @@ package conf
 
 import com.gu.config.SubsV2ProductIds
 import com.gu.memsub.subsv2
-import com.gu.okhttp.RequestRunners.futureRunner
-import com.gu.zuora.{ZuoraApiConfig, rest}
+import com.gu.memsub.subsv2.services.FetchCatalog
 import com.typesafe.config.Config
-
 import scala.concurrent.duration._
 import scala.concurrent.{Await, Future}
 import scala.concurrent.ExecutionContext.Implicits.global
 import scalaz.std.scalaFuture._
 
 object CatalogService {
-  def fromConfig(config: Config, env: String)={
-    val simpleRestClient = new rest.SimpleClient[Future](ZuoraApiConfig.rest(config.getConfig(s"touchpoint.backend.environments.${env}"),env), futureRunner)
 
-    new subsv2.services.CatalogService[Future](SubsV2ProductIds(config.getConfig(s"touchpoint.backend.environments.$env.zuora.productIds")), simpleRestClient, Await.result(_, 10.seconds), env)
+  def fromConfig(config: Config, env: String) = {
+    new subsv2.services.CatalogService[Future](
+      SubsV2ProductIds(config.getConfig(s"touchpoint.backend.environments.$env.zuora.productIds")),
+      FetchCatalog.fromS3(env),
+      Await.result(_, 10.seconds),
+      env)
   }
 
 }

--- a/build.sbt
+++ b/build.sbt
@@ -50,7 +50,7 @@ libraryDependencies ++= Seq(
   cache,
   ws,
   "org.scalaz" %% "scalaz-core" % "7.2.7",
-  "com.gu" %% "membership-common" % "0.515",
+  "com.gu" %% "membership-common" % "0.516",
   "com.gu" %% "memsub-common-play-auth" % "1.2",
   "com.softwaremill.macwire" %% "macros" % "2.2.2" % "provided",
   "com.softwaremill.macwire" %% "util" % "2.2.2",


### PR DESCRIPTION
Pulls in https://github.com/guardian/membership-common/pull/576 so that we can load the catalog from S3 and remove the ZuoraApiConfig.

This will allow us to remove Zuora credentials from the private conf for this app.