### PR TITLE
Only one managed group should have access to the tool

### DIFF
--- a/app/actions/GoogleAuthAction.scala
+++ b/app/actions/GoogleAuthAction.scala
@@ -23,15 +23,7 @@ class GoogleAuthAction(config: Config, ws: WSClient)(implicit ec: ExecutionConte
   lazy val groupChecker = googleGroupCheckerFor(config)
 
   val GoogleAuthAction: ActionBuilder[GoogleAuthRequest] = AuthAction andThen requireGroup[GoogleAuthRequest](Set(
-    "directteam@guardian.co.uk",
-    "subscriptions.dev@guardian.co.uk",
-    "memsubs.dev@guardian.co.uk",
-    "membership.wildebeest@guardian.co.uk",
-    "identitydev@guardian.co.uk",
-    "touchpoint@guardian.co.uk",
-    "crm@guardian.co.uk",
-    "membership.testusers@guardian.co.uk",
-    "acquisition@guardian.co.uk"
+    "subscriptions-promotion-tool@guardian.co.uk"  // Managed by Reader Revenue Dev Managers.
   ))
 }
 


### PR DESCRIPTION
As part of GDPR CyberEssentials we are encouraged to manage access to systems at a personal level via a documented process, rather than adding Google groups which are then in the control of other people.

cc @jacobwinch @davidfurey 