### PR TITLE
[DO NOT MERGE - RFC] - Create a scheduled backup lambda

### DIFF
--- a/cloudformation/memsub-promotions-lambdas-cf.yaml
+++ b/cloudformation/memsub-promotions-lambdas-cf.yaml
@@ -17,7 +17,7 @@ Parameters:
     Type: String
     Default: ''
 Resources:
-  MembershipSubPromotionsToolRole:
+  MembershipSubPromoCodeViewLambdaRole:
     Type: AWS::IAM::Role
     Properties:
       AssumeRolePolicyDocument:
@@ -30,7 +30,7 @@ Resources:
           - sts:AssumeRole
       Path: /
       Policies:
-      - PolicyName: MembershipSub-Promotions-Tool-Policy
+      - PolicyName: MembershipSub-Promo-Code-View-Lambda-Policy
         PolicyDocument:
           Version: '2012-10-17'
           Statement:
@@ -59,7 +59,44 @@ Resources:
             - arn:aws:dynamodb:*:*:table/MembershipSub-PromoCode-View-PROD
             - arn:aws:dynamodb:*:*:table/MembershipSub-PromoCode-View-UAT
             - arn:aws:dynamodb:*:*:table/MembershipSub-PromoCode-View-DEV
-  MembershipSubPromotionsDataRole:
+  MembershipSubPromotionsDataBackupLambdaRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Statement:
+        - Effect: Allow
+          Principal:
+            Service:
+            - lambda.amazonaws.com
+          Action:
+          - sts:AssumeRole
+      Path: /
+      Policies:
+      - PolicyName: MembershipSub-Promotions-Data-Backup-Lambda-Policy
+        PolicyDocument:
+          Version: '2012-10-17'
+          Statement:
+          - Effect: Allow
+            Action:
+            - logs:CreateLogGroup
+            - logs:CreateLogStream
+            - logs:PutLogEvents
+            Resource:
+            - arn:aws:logs:*:*:log-group:/aws/lambda/MembershipSub-Promotions-Scheduled-Dynamo-Backup-*
+          - Effect: Allow
+            Action:
+            - dynamodb:GetRecords
+            - dynamodb:Scan
+            Resource:
+            - arn:aws:dynamodb:*:*:table/MembershipSub-Promotions-*
+            - arn:aws:dynamodb:*:*:table/MembershipSub-Campaigns-*
+          - Effect: Allow
+            Action:
+            - dynamodb:ListBackups
+            - dynamodb:DescribeBackup
+            Resource:
+            - *
+  MembershipSubPromoCodeViewETLRole:
     Type: AWS::IAM::Role
     Properties:
       AssumeRolePolicyDocument:
@@ -109,7 +146,7 @@ Resources:
       FunctionName: MembershipSub-Promotions-to-PromoCode-View-DEV
       Handler: MembershipSub-Promotions-to-PromoCode-View-Lambda.handler
       MemorySize: 128
-      Role: !GetAtt [MembershipSubPromotionsToolRole, Arn]
+      Role: !GetAtt [MembershipSubPromoCodeViewLambdaRole, Arn]
       Runtime: nodejs6.10
       Timeout: 10
   PromoCodeViewLambdaFunctionUAT:
@@ -123,7 +160,7 @@ Resources:
       FunctionName: MembershipSub-Promotions-to-PromoCode-View-UAT
       Handler: MembershipSub-Promotions-to-PromoCode-View-Lambda.handler
       MemorySize: 128
-      Role: !GetAtt [MembershipSubPromotionsToolRole, Arn]
+      Role: !GetAtt [MembershipSubPromoCodeViewLambdaRole, Arn]
       Runtime: nodejs6.10
       Timeout: 10
   PromoCodeViewLambdaFunctionPROD:
@@ -137,7 +174,7 @@ Resources:
       FunctionName: MembershipSub-Promotions-to-PromoCode-View-PROD
       Handler: MembershipSub-Promotions-to-PromoCode-View-Lambda.handler
       MemorySize: 128
-      Role: !GetAtt [MembershipSubPromotionsToolRole, Arn]
+      Role: !GetAtt [MembershipSubPromoCodeViewLambdaRole, Arn]
       Runtime: nodejs6.10
       Timeout: 10
   PromoCodeViewLambdaEventSourceDEV:
@@ -175,7 +212,7 @@ Resources:
       FunctionName: MembershipSub-PromoCode-View-Dynamo-to-Data-Lake-PROD
       Handler: MembershipSub-PromoCode-View-Dynamo-to-Data-Lake.handler
       MemorySize: 128
-      Role: !GetAtt [MembershipSubPromotionsDataRole, Arn]
+      Role: !GetAtt [MembershipSubPromoCodeViewETLRole, Arn]
       Runtime: nodejs6.10
       Timeout: 10
 
@@ -196,7 +233,7 @@ Resources:
         - Sid: Allow use of the key
           Effect: Allow
           Principal:
-            AWS: !GetAtt [MembershipSubPromotionsDataRole, Arn]
+            AWS: !GetAtt [MembershipSubPromoCodeViewETLRole, Arn]
           Action:
           - kms:Encrypt
           - kms:Decrypt
@@ -220,7 +257,7 @@ Resources:
       FunctionName: MembershipSub-PromoCode-View-Dynamo-to-Salesforce-DEV
       Handler: MembershipSub-PromoCode-View-Dynamo-to-Salesforce.handler
       MemorySize: 128
-      Role: !GetAtt [MembershipSubPromotionsDataRole, Arn]
+      Role: !GetAtt [MembershipSubPromoCodeViewETLRole, Arn]
       Runtime: nodejs6.10
       Timeout: 10
       KmsKeyArn: !GetAtt SalesforceLambdaKMSKey.Arn
@@ -234,7 +271,7 @@ Resources:
       FunctionName: MembershipSub-PromoCode-View-Dynamo-to-Salesforce-UAT
       Handler: MembershipSub-PromoCode-View-Dynamo-to-Salesforce.handler
       MemorySize: 128
-      Role: !GetAtt [MembershipSubPromotionsDataRole, Arn]
+      Role: !GetAtt [MembershipSubPromoCodeViewETLRole, Arn]
       Runtime: nodejs6.10
       Timeout: 10
       KmsKeyArn: !GetAtt SalesforceLambdaKMSKey.Arn
@@ -248,7 +285,36 @@ Resources:
       FunctionName: MembershipSub-PromoCode-View-Dynamo-to-Salesforce-PROD
       Handler: MembershipSub-PromoCode-View-Dynamo-to-Salesforce.handler
       MemorySize: 128
-      Role: !GetAtt [MembershipSubPromotionsDataRole, Arn]
+      Role: !GetAtt [MembershipSubPromoCodeViewETLRole, Arn]
       Runtime: nodejs6.10
       Timeout: 10
       KmsKeyArn: !GetAtt SalesforceLambdaKMSKey.Arn
+  ScheduledBackupLambdaPROD:
+    Type: AWS::Lambda::Function
+    Properties:
+      Code:
+        S3Bucket: gu-promotions-tool-dist
+        S3Key: membership/PROD/MembershipSub-Promotions-PromoCode-View/MembershipSub-Promotions-PromoCode-View.zip
+      Description: A Lambda function to schedule the backup of the Campaigns and Promotions table
+      FunctionName: MembershipSub-Promotions-Scheduled-Dynamo-Backup-PROD
+      Handler: MembershipSub-Promotions-Scheduled-Dynamo-Backup.handler
+      MemorySize: 128
+      Role: !GetAtt [MembershipSubPromotionsDataBackupLambdaRole, Arn]
+      Runtime: nodejs6.10
+      Timeout: 10
+      KmsKeyArn: !GetAtt SalesforceLambdaKMSKey.Arn
+  BackupSchedule:
+    Type: AWS::Events::Rule
+    Properties:
+      ScheduleExpression: cron(0 12 * * ? *)
+      State: String
+      Targets:
+        Id: ScheduledBackupLambdaPRODScheduler
+        Arn: !GetAtt [ScheduledBackupLambdaPROD, Arn]
+  InvokeLambdaPermission:
+    Type: AWS::Lambda::Permission
+    Properties:
+      FunctionName: !GetAtt [ScheduledBackupLambdaPROD, Arn]
+      Action: lambda:InvokeFunction
+      Principal: events.amazonaws.com
+      SourceArn: !GetAtt [BackupSchedule, Arn]

--- a/lambdas/riff-raff.yaml
+++ b/lambdas/riff-raff.yaml
@@ -13,3 +13,4 @@ deployments:
       - MembershipSub-Promotions-to-PromoCode-View-
       - MembershipSub-PromoCode-View-Dynamo-to-Data-Lake-
       - MembershipSub-PromoCode-View-Dynamo-to-Salesforce-
+      - MembershipSub-Promotions-Scheduled-Dynamo-Backup-

--- a/lambdas/src/MembershipSub-PromoCode-View-Dynamo-to-Data-Lake.js
+++ b/lambdas/src/MembershipSub-PromoCode-View-Dynamo-to-Data-Lake.js
@@ -13,7 +13,8 @@ function enquote(anArray) {
 
 exports.handler = (event, context, callback) => {
 
-    const source = /PROD$/.test(context.functionName) ? 'PROD' : 'UAT';
+    const source = 'PROD'; // Only PROD PromoCode-View data goes to the Data Lake.
+
     const TableName = `MembershipSub-PromoCode-View-${source}`;
     const Bucket = 'ophan-raw-membership-promo-code-view';
     const Key = TableName + '.csv';

--- a/lambdas/src/MembershipSub-PromoCode-View-Dynamo-to-Salesforce.js
+++ b/lambdas/src/MembershipSub-PromoCode-View-Dynamo-to-Salesforce.js
@@ -246,7 +246,7 @@ function makeAPICalls(csvData) {
 
 exports.handler = (event, context, callback) => {
 
-    const source = /PROD$/.test(context.functionName) ? 'PROD' : 'UAT';
+    const TOUCHPOINT_BACKEND = /PROD$/.test(context.functionName) ? 'PROD' : /UAT$/.test(context.functionName) ? 'UAT' : 'DEV';
     const TableName = `MembershipSub-PromoCode-View-${source}`;
 
     docClient.scan({ TableName })

--- a/lambdas/src/MembershipSub-Promotions-Scheduled-Dynamo-Backup.js
+++ b/lambdas/src/MembershipSub-Promotions-Scheduled-Dynamo-Backup.js
@@ -1,0 +1,65 @@
+const AWS = require('aws-sdk');
+
+const ddb = new AWS.DynamoDB();
+
+function createTodaysBackup(TableName) {
+    return ddb.createBackup({
+        'BackupName': `${TableName}-Scheduled-Backup`,
+        TableName
+    })
+        .promise()
+        .then(possiblyJustCreatedBackup => {
+            console.log(`Created backup of table ${TableName}: ${possiblyJustCreatedBackup.BackupDetails.BackupArn}`);
+            return possiblyJustCreatedBackup.BackupDetails.BackupArn;
+        });
+}
+
+function deleteBackupsOlderThanXDays(TableName, retentionDays) {
+    return (latestBackupARN) => {
+        const unixtime = Math.floor(Date.now() / 1000);
+        const retentionSeconds = (retentionDays * 60 * 60 * 24);
+        const TimeRangeUpperBound = unixtime - retentionSeconds;
+
+        return ddb.listBackups({
+            TableName,
+            TimeRangeUpperBound
+        })
+            .promise()
+            .then(oldBackups => {
+
+                const backupsToDelete = oldBackups.BackupSummaries.map(backupSummary => backupSummary.BackupArn).filter(backupArn => latestBackupARN !== backupArn)
+
+                console.log(`${backupsToDelete.length} old backups for table: ${TableName} will be deleted...`);
+
+                const deletionPromises = backupsToDelete.map(BackupArn => {
+                    console.log(`Attempting to delete backup: ${BackupArn}`);
+                    return ddb.deleteBackup({ BackupArn }).promise();
+                });
+
+                return Promise.all(deletionPromises).then(results => {
+                    results.forEach(result => {
+                        console.log(`Successfully deleted ${result.BackupDescription.BackupDetails.BackupArn}`)
+                    });
+                    console.log(`Successfully deleted ${results.length} backups for table: ${TableName}`);
+                    return `Successfully${latestBackupARN ? ' created new backup and' : ''} deleted ${results.length} backups for table: ${TableName}`;
+                })
+            });
+    }
+}
+
+exports.handler = (event, context, callback) => {
+
+    const TOUCHPOINT_BACKEND = /PROD$/.test(context.functionName) ? 'PROD' : 'UAT';
+    const retentionDays = 14; // a number < 1 will delete everything except the backup `createTodaysBackup` just created
+
+    const tablesToBackup = [
+        `MembershipSub-Campaigns-${TOUCHPOINT_BACKEND}`,
+        `MembershipSub-Promotions-${TOUCHPOINT_BACKEND}`
+    ];
+    Promise.all(tablesToBackup.map(tableName => createTodaysBackup(tableName).then(deleteBackupsOlderThanXDays(tableName, retentionDays))))
+        .then((results) => {
+            callback(null, `Backup report: ${results.join('; ')}`)
+        })
+        .catch(callback)
+
+};

--- a/lambdas/src/MembershipSub-Promotions-to-PromoCode-View-Lambda.js
+++ b/lambdas/src/MembershipSub-Promotions-to-PromoCode-View-Lambda.js
@@ -110,7 +110,7 @@ function attemptToComplete(callback) {
 
 exports.handler = (event, context, callback) => {
 
-    const TOUCHPOINT_BACKEND = /PROD$/.test(context.functionName) ? 'PROD' : 'UAT';
+    const TOUCHPOINT_BACKEND = /PROD$/.test(context.functionName) ? 'PROD' : /UAT$/.test(context.functionName) ? 'UAT' : 'DEV';
 
     docClient.scan({
         TableName: 'MembershipSub-Campaigns-' + TOUCHPOINT_BACKEND


### PR DESCRIPTION
Right now we manage the promotion Dynamo DB backups through a Data Pipeline job. This method is much cheaper. 

What do people think about doing scheduled backups this way?  @jacobwinch @davidfurey @rupertbates 

An alternative is to enable continuous backups, but they don't protect against someone deleting the table.

Changes:
- Create a scheduled backup lambda. 
- Also tidied up some CFN and environment configs.
