### PR TITLE
bump jackson-databind and jackson-annotations to 2.9.7

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -66,7 +66,8 @@ libraryDependencies ++= Seq(
   "io.netty" % "netty" % "3.10.3.Final",
   "ch.qos.logback" % "logback-classic" % "1.2.3",
 // This is required to force aws libraries to use the latest version of jackson
-  "com.fasterxml.jackson.core" % "jackson-databind" % "2.8.11.1",
+  "com.fasterxml.jackson.core" % "jackson-databind" % "2.9.7",
+  "com.fasterxml.jackson.core" % "jackson-annotations" % "2.9.7", //ditto
   "org.scalatestplus.play" %% "scalatestplus-play" % "3.1.2" % Test
 )
 


### PR DESCRIPTION
### Why are you doing this?
https://snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-31507

We are pulling in old versions of jackson-databind via aws-sdks (the promo code tool needs to interact with dynamo). It's suggested here that overriding jackson-databind shouldn't be a breaking change. 

We are also pulling in an old version of jackson-databind to support Google auth.

I bumped the versions, signed in via my google account, and checked to see that some promo codes were coming through from the dynamo table.

Any other suggested checks?

### Trello Card
// none. Inspired by Snyk.

### Changes
Bumped jackson-databind and jackson-annotations to 2.9.7
