### PR TITLE
bumps membership-common dependency

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -58,7 +58,7 @@ libraryDependencies ++= Seq(
   cache,
   ws,
   "org.scalaz" %% "scalaz-core" % "7.2.7",
-  "com.gu" %% "membership-common" % "0.524",
+  "com.gu" %% "membership-common" % "0.526",
   "com.gu" %% "play-googleauth" % "0.7.7",
   "com.softwaremill.macwire" %% "macros" % "2.3.1" % "provided",
   "com.softwaremill.macwire" %% "util" % "2.3.1",


### PR DESCRIPTION
This PR addresses a [snyk issue](https://app.snyk.io/org/the-guardian-cuu/project/d0c4fcd7-5943-49b1-878b-c7a8e9d64236/) as a result of depending on `com.gu.membership.common`. 

@johnduffell fixed the issue with membeship.common [with this PR](https://github.com/guardian/membership-common/pull/584) . Bumping version to use this 'fixed' version. 