### PR TITLE
Fix Lambda Dynamo IAM permissions

### DIFF
--- a/cloudformation/memsub-promotions-lambdas-cf.yaml
+++ b/cloudformation/memsub-promotions-lambdas-cf.yaml
@@ -95,6 +95,7 @@ Resources:
             - dynamodb:CreateBackup
             - dynamodb:ListBackups
             - dynamodb:DescribeBackup
+            - dynamodb:DeleteBackup
             Resource:
             - '*'
   MembershipSubPromoCodeViewETLRole:


### PR DESCRIPTION
The Lambda was prevented from deleting old backups due to this permision not being there. This might have also been causing the Lambda to execute three times.

Thanks for spotting that @pvighi!