### PR TITLE
bump jackson-databind and jackson-annotations to 2.9.8

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -53,6 +53,8 @@ javaOptions in Universal ++= Seq(
 scalaVersion := "2.12.4"
 scalacOptions ++= Seq("-feature")
 
+val jacksonVersion = "2.9.8"
+
 libraryDependencies ++= Seq(
   jdbc,
   cache,
@@ -66,8 +68,8 @@ libraryDependencies ++= Seq(
   "io.netty" % "netty" % "3.10.3.Final",
   "ch.qos.logback" % "logback-classic" % "1.2.3",
 // This is required to force aws libraries to use the latest version of jackson
-  "com.fasterxml.jackson.core" % "jackson-databind" % "2.9.7",
-  "com.fasterxml.jackson.core" % "jackson-annotations" % "2.9.7", //ditto
+  "com.fasterxml.jackson.core" % "jackson-databind" % jacksonVersion,
+  "com.fasterxml.jackson.core" % "jackson-annotations" % jacksonVersion, //ditto
   "org.scalatestplus.play" %% "scalatestplus-play" % "3.1.2" % Test
 )
 

--- a/nginx/promotions.conf
+++ b/nginx/promotions.conf
@@ -12,8 +12,8 @@ server {
     server_name promo.thegulocal.com;
 
     ssl on;
-    ssl_certificate wildcard-thegulocal-com-exp2019-01-09.crt;
-    ssl_certificate_key wildcard-thegulocal-com-exp2019-01-09.key;
+    ssl_certificate STAR_thegulocal_com_exp2020-01-09.crt;
+    ssl_certificate_key STAR_thegulocal_com_exp2020-01-09.key;
 
     ssl_session_timeout 5m;
 


### PR DESCRIPTION
Here we go again. See description here: https://github.com/guardian/memsub-promotions/pull/130

Here's the Snyk issue:
https://app.snyk.io/org/the-guardian-cuu/project/d0c4fcd7-5943-49b1-878b-c7a8e9d64236/

Changes:
* update jackson-databind and jackson-annotations to 2.9.8
* Have also updated the certificate in the nginx config

I ran the app locally and just checked that there were promo codes coming through