### PR TITLE
Prevent invalid product rate plan ids from being written to Dynamo

### DIFF
--- a/app/controllers/PromotionController.scala
+++ b/app/controllers/PromotionController.scala
@@ -72,7 +72,7 @@ class PromotionController(
       case Right(promo) if productRatePlanIdsAreValidForStage(promo) =>
         Ok(Json.obj("status" -> "ok"))
       case Right(promo) =>
-        logger.warn(s"Failed to validate promotion $jsonValidationAttempt against $stage catalog")
+        logger.warn(s"Failed to validate promotion $promo against $stage catalog")
         InternalServerError
       case Left(error) =>
         logger.warn(s"Failed to parse promotion JSON correctly due to $error")

--- a/app/controllers/PromotionController.scala
+++ b/app/controllers/PromotionController.scala
@@ -8,14 +8,23 @@ import com.gu.memsub.promo.Formatters.PromotionFormatters._
 import com.gu.memsub.promo.Promotion.AnyPromotion
 import com.gu.memsub.promo._
 import com.gu.memsub.services.JsonDynamoService
+import com.gu.memsub.subsv2.services.CatalogService
+import com.typesafe.scalalogging.LazyLogging
 import org.joda.time.DateTimeZone
 import play.api.libs.json.{JsError, JsPath, Json, JsonValidationError}
 import play.api.mvc.Result
 import play.api.mvc.Results._
+import wiring.AppComponents.Stage
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.Try
 
-class PromotionController(googleAuthAction: GoogleAuthenticatedAction, service: JsonDynamoService[AnyPromotion, Future], implicit val ec: ExecutionContext) {
+class PromotionController(
+  stage: Stage,
+  googleAuthAction: GoogleAuthenticatedAction,
+  catalogService: CatalogService[Future],
+  dynamoService: JsonDynamoService[AnyPromotion, Future],
+  implicit val ec: ExecutionContext
+) extends LazyLogging {
 
   private val londonTimezone = DateTimeZone.forTimeZone(TimeZone.getTimeZone("Europe/London"))
 
@@ -34,13 +43,23 @@ class PromotionController(googleAuthAction: GoogleAuthenticatedAction, service: 
   }
 
   def all(campaignCode: Option[String]) = googleAuthAction.async {
-    campaignCode.map(CampaignCode).fold(service.all)(service.find).map(promos => Ok(Json.toJson(promos.sortBy(_.name))))
+    campaignCode.map(CampaignCode).fold(dynamoService.all)(dynamoService.find).map(promos => Ok(Json.toJson(promos.sortBy(_.name))))
   }
 
   def get(uuid: Option[String]) = googleAuthAction.async {
     uuid.flatMap(i => Try(UUID.fromString(i)).toOption).map {
-      i => service.find(i).map(_.headOption.fold[Result](NotFound)(promo => Ok(Json.toJson(promo))))
+      i => dynamoService.find(i).map(_.headOption.fold[Result](NotFound)(promo => Ok(Json.toJson(promo))))
     }.getOrElse[Future[Result]](Future.successful(BadRequest))
+  }
+
+  def productRatePlanIdsAreValidForStage(promo: AnyPromotion): Boolean = promo.appliesTo.productRatePlanIds.forall {
+    productRatePlanId => {
+      val productRatePlanIdIsInCatalog = catalogService.unsafeCatalog.paid.exists(_.id == productRatePlanId)
+      if (!productRatePlanIdIsInCatalog) {
+        logger.info(s"$productRatePlanId was not found in the $stage catalog")
+      }
+      productRatePlanIdIsInCatalog
+    }
   }
 
   def validate = googleAuthAction { request =>
@@ -53,13 +72,17 @@ class PromotionController(googleAuthAction: GoogleAuthenticatedAction, service: 
   def upsert = googleAuthAction.async { request =>
     request.body.asJson.map { json =>
       json.validate[AnyPromotion].map { promotion => {
-        service.add(normaliseDateTimes(promotion)).map(_ => Ok(Json.obj("status" -> "ok")))
+        if (productRatePlanIdsAreValidForStage(promotion)) {
+          dynamoService.add(normaliseDateTimes(promotion)).map(_ => Ok(Json.obj("status" -> "ok")))
+        } else {
+          Future.successful(BadRequest(s"Product Rate Plan Ids in request are not valid for ${stage}"))
+        }
       }
       }.recoverTotal{
-        e => Future(BadRequest("Detected error:"+ JsError.toJson(e)))
+        e => Future.successful(BadRequest("Detected error:"+ JsError.toJson(e)))
       }
     }.getOrElse {
-      Future(BadRequest("Could not parse campaign data"))
+      Future.successful(BadRequest("Could not parse campaign data"))
     }
   }
 }

--- a/app/controllers/PromotionController.scala
+++ b/app/controllers/PromotionController.scala
@@ -70,13 +70,13 @@ class PromotionController(
 
     jsonValidationAttempt match {
       case Right(promo) if productRatePlanIdsAreValidForStage(promo) =>
-        Ok(Json.obj("status" -> "ok"))
+        Ok
       case Right(promo) =>
         logger.warn(s"Failed to validate promotion $promo against $stage catalog")
-        InternalServerError
-      case Left(error) =>
-        logger.warn(s"Failed to parse promotion JSON correctly due to $error")
-        BadRequest
+        InternalServerError(Json.obj("failureReason" -> s"Attempted to update a $stage promotion with invalid product rate plan ids"))
+      case Left(errors) =>
+        logger.warn(s"Failed to parse promotion JSON correctly due to $errors")
+        BadRequest(JsError.toJson(errors))
     }
 
   }

--- a/frontend/src/services/PromotionService.es6
+++ b/frontend/src/services/PromotionService.es6
@@ -58,17 +58,17 @@ export default class {
             method: 'POST',
             url: '/promotion/validate',
             data: promotion
-        }).then(r => {
-            let data = r.data;
-            if (data.status && data.status === 'ok') {
-                return this.$q.resolve(promotion);
+        }).then(() => {
+              return this.$q.resolve(promotion);
+          },
+          errorResponse => {
+            if (errorResponse.status === 400) {
+              return this.$q.reject(Object.keys(errorResponse.data).map(f =>
+                f + ": " + errorResponse.data[f].map(e => e.msg.join(" ")).join(" ")
+              ));
             } else {
-                return this.$q.reject(Object.keys(data).map(f => 
-                    f + ": " + data[f].map(e => e.msg.join(" ")).join(" ")
-                ));
+                return this.$q.reject([errorResponse.data.failureReason]);
             }
-        }, e => {
-            return this.$q.reject([e.status + " " + e.statusText])
         })
     }
 }

--- a/frontend/src/templates/PromotionForm.html
+++ b/frontend/src/templates/PromotionForm.html
@@ -37,7 +37,7 @@
                 </section>
 
                 <div class="server-error" ng-if="serverErrors.length">
-                    Internal server error while saving promotion:
+                    There was an error while saving the promotion:
                     <ul><li ng-repeat="err in serverErrors">{{err}}</li></ul>
                     Please send this report to a developer.
                 </div>


### PR DESCRIPTION
In response to a production issue where promo codes linked to DEV/UAT product rate plan ids were added to the PROD Dynamo table 😱 

Full details are here: https://trello.com/c/OIpRqlVn/2219-investigate-misalignment-of-digital-pack-promo-code

The user (who is likely to be a developer anyway) will now see the following error message if there is a mismatch between the stage cookie and the product rate plan ids linked to the promo:

![image](https://user-images.githubusercontent.com/19384074/54273943-d861e180-457e-11e9-88b5-9ae0490a8422.png)

The logging also now contains an explanation of why the validation has been failed so we can work out what's going wrong.