### PR TITLE
Updating to latest membership-common to pick up the oneYear GW palns

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -60,7 +60,7 @@ libraryDependencies ++= Seq(
   cache,
   ws,
   "org.scalaz" %% "scalaz-core" % "7.2.7",
-  "com.gu" %% "membership-common" % "0.527",
+  "com.gu" %% "membership-common" % "0.548",
   "com.gu" %% "play-googleauth" % "0.7.7",
   "com.softwaremill.macwire" %% "macros" % "2.3.1" % "provided",
   "com.softwaremill.macwire" %% "util" % "2.3.1",


### PR DESCRIPTION
Updating to latest membership-common to pick up the oneYear GW rate plans in the PromoCode tool introduced in v0.533 and https://github.com/guardian/membership-common/commit/cf8765205abee48f53604c50ad8828a8b3773f60

This fixes the issue where no prices and discounts show up against the rate plans, and makes the promotion uneditable.

Before in CODE:

![Screen Shot 2019-05-24 at 15 13 11](https://user-images.githubusercontent.com/1515970/58333984-84a12d80-7e36-11e9-8b8b-a298c58e0281.png)

After in CODE:

![Screen Shot 2019-05-24 at 15 20 11](https://user-images.githubusercontent.com/1515970/58334427-71db2880-7e37-11e9-8b93-c326b43b4d89.png)

cc @rupertbates @arausuy @jorgeazevedo 