### PR TITLE
Disabling allocation of external IP address as this box is now inside the private subnet

### DIFF
--- a/cloudformation/memsub-promotions-cf.yaml
+++ b/cloudformation/memsub-promotions-cf.yaml
@@ -201,7 +201,7 @@ Resources:
       SecurityGroups:
       - !Ref 'InstanceSecurityGroup'
       InstanceType: !Ref 'InstanceType'
-      AssociatePublicIpAddress: 'True'
+      AssociatePublicIpAddress: 'False'
       IamInstanceProfile: !Ref 'InstanceProfile'
       UserData:
         "Fn::Base64":


### PR DESCRIPTION
Disabling allocation of an external IP address as this box is now inside the private subnet.

Tested on CODE.