### PR TITLE
snyk: update jackson version and apache commons httpclient

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -60,7 +60,7 @@ libraryDependencies ++= Seq(
   cache,
   ws,
   "org.scalaz" %% "scalaz-core" % "7.2.7",
-  "com.gu" %% "membership-common" % "0.548",
+  "com.gu" %% "membership-common" % "0.549",
   "com.gu" %% "play-googleauth" % "0.7.7",
   "com.softwaremill.macwire" %% "macros" % "2.3.1" % "provided",
   "com.softwaremill.macwire" %% "util" % "2.3.1",
@@ -70,7 +70,7 @@ libraryDependencies ++= Seq(
   "org.scalatestplus.play" %% "scalatestplus-play" % "3.1.2" % Test,
 
   // All the below are required to force aws libraries to use the latest version of jackson
-  "com.fasterxml.jackson.core" % "jackson-databind" % jacksonVersion,
+  "com.fasterxml.jackson.core" % "jackson-databind" % (jacksonVersion+".1"),
   "com.fasterxml.jackson.core" % "jackson-annotations" % jacksonVersion,
   "com.fasterxml.jackson.dataformat" % "jackson-dataformat-cbor" % jacksonVersion,
   "com.fasterxml.jackson.datatype" % "jackson-datatype-jdk8" % jacksonVersion,

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,4 +1,4 @@
 #Activator-generated Properties
 #Wed Apr 27 13:51:21 BST 2016
 template.uuid=86f70d51-c929-4089-b3cd-cd0e266e7c01
-sbt.version=1.0.2
+sbt.version=1.2.8


### PR DESCRIPTION
The https://app.snyk.io/vuln/SNYK-JAVA-ORGAPACHEHTTPCOMPONENTS-31517
and https://app.snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-450917
are present in the promo tool.
Even though it's internal, it makes sense to keep things up to date.

I have also updated the SBT version to keep things sensible.

Depends on the PR I shipped yesterday: https://github.com/guardian/membership-common/pull/600