### PR TITLE
update jackson version for snyk

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -50,10 +50,10 @@ javaOptions in Universal ++= Seq(
   s"-J-Xloggc:/var/log/${packageName.value}/gc.log"
 )
 
-scalaVersion := "2.12.4"
+scalaVersion := "2.12.10"
 scalacOptions ++= Seq("-feature")
 
-val jacksonVersion = "2.9.9"
+val jacksonVersion = "2.10.0"
 
 libraryDependencies ++= Seq(
   jdbc,
@@ -70,7 +70,7 @@ libraryDependencies ++= Seq(
   "org.scalatestplus.play" %% "scalatestplus-play" % "3.1.2" % Test,
 
   // All the below are required to force aws libraries to use the latest version of jackson
-  "com.fasterxml.jackson.core" % "jackson-databind" % (jacksonVersion+".1"),
+  "com.fasterxml.jackson.core" % "jackson-databind" % jacksonVersion,
   "com.fasterxml.jackson.core" % "jackson-annotations" % jacksonVersion,
   "com.fasterxml.jackson.dataformat" % "jackson-dataformat-cbor" % jacksonVersion,
   "com.fasterxml.jackson.datatype" % "jackson-datatype-jdk8" % jacksonVersion,

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,4 +1,4 @@
 #Activator-generated Properties
 #Wed Apr 27 13:51:21 BST 2016
 template.uuid=86f70d51-c929-4089-b3cd-cd0e266e7c01
-sbt.version=1.2.8
+sbt.version=1.3.2

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -23,6 +23,6 @@ addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.3.4")
 
 addSbtPlugin("com.gu" % "sbt-riffraff-artifact" % "1.1.3")
 
-addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.9.0")
+addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.10.0-RC1")
 
 libraryDependencies += "org.vafer" % "jdeb" % "1.5" artifacts (Artifact("jdeb", "jar", "jar"))


### PR DESCRIPTION
this updates jackson databind for the usual snyk issue.
also bumps scala/sbt versions, and also the sbt-dependency graph as that is needed for snyk monitor and the newer version is needed for latest sbt.
@alexflav23 @twrichards 