### PR TITLE
Update the landing page description field label

### DIFF
--- a/frontend/src/templates/LandingPage.html
+++ b/frontend/src/templates/LandingPage.html
@@ -42,7 +42,8 @@
             <label>Subtitle</label><input name="subtitle" ng-model="promotion.landingPage.subtitle" delete-empty>
         </md-input-container>
         <md-input-container>
-            <label>Description</label><textarea name="landing-description" ng-model="promotion.landingPage.description" delete-empty></textarea>
+            <label>Description (supports a subset of <a href="https://guides.github.com/features/mastering-markdown/#examples">Github markdown</a>)</label>
+            <textarea name="landing-description" ng-model="promotion.landingPage.description" delete-empty></textarea>
         </md-input-container>
         <md-input-container>
             <label>Roundel</label><textarea name="roundel-html" ng-model="promotion.landingPage.roundelHtml" delete-empty></textarea>


### PR DESCRIPTION
Add a note to the label of the landing page description field so that users are aware that they may use a subset of Github Markdown in the field