### PR TITLE
Update the promo description field label

### DIFF
--- a/frontend/src/templates/PromotionForm.html
+++ b/frontend/src/templates/PromotionForm.html
@@ -13,7 +13,7 @@
                     </div>
                 </md-input-container>
                 <md-input-container class="md-block">
-                    <label>Description (for checkout page when promotion applied)</label>
+                    <label>Description (for checkout page summary and product page price card)</label>
                     <input ng-model="promotion.description" name="description" required/>
                     <div ng-messages="promotionForm.description.$error" role="alert">
                         <ng-message when="required">Please enter a description</ng-message>


### PR DESCRIPTION
The promotion description field is now used in product page price cards as well as the checkout summary, so this PR updates the field description to reflect this:

![Screenshot 2019-10-23 at 15 49 34](https://user-images.githubusercontent.com/181371/67405538-d21ff300-f5ac-11e9-8aba-fd75eaffe11c.png)
