### PR TITLE
Use dev nginx

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-Memsubity promotions
+Subscription promotions tool
 ====================
 
 ### NGinx

--- a/README.md
+++ b/README.md
@@ -2,27 +2,9 @@ Memsubity promotions
 ====================
 
 ### NGinx
-
-#### First, setup Nginx for `Identity-Platform`
-
-Set up Nginx config and SSL certs from Identity. Follow the README
-[here](https://github.com/guardian/identity-platform/blob/master/README.md#setup-nginx-for-local-development)
-first, before you do anything else but make sure to pass the profile 'membership' to the script:
-
-Within `identity-platform`, run:
-   ```
-   sudo -E nginx/setup.sh membership --with-jdk-import
-   ```
-and enter your password where prompted.
-
-#### Then, run the Nginx setup script specific to `memsub-promotions`
-
-Run the `memsub-promotions`-specific [setup.sh](nginx/setup.sh) script from the root
-of the `memsub-promotions` project:
-
-```
-./nginx/setup.sh
-```
+1. `cd nginx`
+1. Install dependencies `brew bundle`
+2. Run `./setup.sh`
 
 ## General Setup
 

--- a/nginx/BrewFile
+++ b/nginx/BrewFile
@@ -1,0 +1,2 @@
+tap "guardian/devtools"
+brew "guardian/devtools/dev-nginx"

--- a/nginx/promotions.conf
+++ b/nginx/promotions.conf
@@ -8,12 +8,11 @@ server {
 }
 
 server {
-    listen 443;
+    listen 443 ssl;
     server_name promo.thegulocal.com;
 
-    ssl on;
-    ssl_certificate STAR_thegulocal_com_exp2020-01-09.crt;
-    ssl_certificate_key STAR_thegulocal_com_exp2020-01-09.key;
+    ssl_certificate promo.thegulocal.com.crt;
+    ssl_certificate_key promo.thegulocal.com.key;
 
     ssl_session_timeout 5m;
 

--- a/nginx/setup.sh
+++ b/nginx/setup.sh
@@ -1,10 +1,9 @@
 #!/bin/bash
+
+set -e
+
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-NGINX_HOME=$(nginx -V 2>&1 | grep 'configure arguments:' | sed 's#.*conf-path=\([^ ]*\)/nginx\.conf.*#\1#g')
 
-echo "this script needs root access to configure nginx, please enter your sudo password if prompted"
-sudo mkdir -p $NGINX_HOME/sites-enabled
-sudo ln -fs $DIR/promotions.conf $NGINX_HOME/sites-enabled/promotions.conf
-
-sudo nginx -s stop
-sudo nginx
+dev-nginx setup-cert promo.thegulocal.com
+dev-nginx link-config $DIR/promotions.conf
+dev-nginx restart-nginx


### PR DESCRIPTION
We are now using dev-nginx to handle SSL certs for local development rather than the Identity platform. This PR updates the promo tool to work the same way.

Based on https://github.com/guardian/subscriptions-frontend/pull/1267/files