### PR TITLE
Landing page tweaks

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -79,8 +79,8 @@ libraryDependencies ++= Seq(
 
 resolvers ++= Seq(
   "Guardian Github Releases" at "https://guardian.github.io/maven/repo-releases",
-  "Guardian Github Snapshots" at "http://guardian.github.com/maven/repo-snapshots",
-  "scalaz-bintray" at "http://dl.bintray.com/scalaz/releases",
+  "Guardian Github Snapshots" at "https://guardian.github.com/maven/repo-snapshots",
+  "scalaz-bintray" at "https://dl.bintray.com/scalaz/releases",
   Resolver.sonatypeRepo("releases"))
 
 addCommandAlias("devrun", "run -Dconfig.resource=DEV.conf 9500")

--- a/frontend/src/templates/LandingPage.html
+++ b/frontend/src/templates/LandingPage.html
@@ -34,7 +34,7 @@
             <label>Subtitle</label><input name="subtitle" ng-model="promotion.landingPage.subtitle" delete-empty>
         </md-input-container>
         <md-input-container>
-            <label>Description</label>
+            <label>Description (supports Markdown)</label>
             <textarea name="landing-description" ng-model="promotion.landingPage.description" delete-empty></textarea>
         </md-input-container>
         <md-input-container>
@@ -42,6 +42,9 @@
         </md-input-container>
 
         <grid-image-selector ng-show="false" image="promotion.landingPage.image" label="an image"></grid-image-selector>
-
+        <span>
+            For examples of how to format text using Markdown see
+            <a href="https://guides.github.com/features/mastering-markdown/#examples" target="_blank">here</a>
+        </span>
     </div>
 </ng-form>

--- a/frontend/src/templates/LandingPage.html
+++ b/frontend/src/templates/LandingPage.html
@@ -27,14 +27,6 @@
                 <md-radio-button value="bottom">Bottom</md-radio-button>
             </md-radio-group>
         </div>
-        <div layout="column" ng-show="weekly">
-            <h5>Title colour</h5>
-            <md-radio-group layout="row" ng-model="promotion.landingPage.sectionColour">
-                <md-radio-button value="blue" class="md-primary">Blue</md-radio-button>
-                <md-radio-button value="grey">Grey</md-radio-button>
-                <md-radio-button value="white">White</md-radio-button>
-            </md-radio-group>
-        </div>
         <md-input-container>
             <label>Title</label><input name="title" ng-model="promotion.landingPage.title" delete-empty/>
         </md-input-container>
@@ -42,23 +34,14 @@
             <label>Subtitle</label><input name="subtitle" ng-model="promotion.landingPage.subtitle" delete-empty>
         </md-input-container>
         <md-input-container>
-            <label>Description (supports a subset of <a href="https://guides.github.com/features/mastering-markdown/#examples">Github markdown</a>)</label>
+            <label>Description</label>
             <textarea name="landing-description" ng-model="promotion.landingPage.description" delete-empty></textarea>
         </md-input-container>
         <md-input-container>
-            <label>Roundel</label><textarea name="roundel-html" ng-model="promotion.landingPage.roundelHtml" delete-empty></textarea>
+            <label>Product page price card</label><textarea name="roundel-html" ng-model="promotion.landingPage.roundelHtml" delete-empty></textarea>
         </md-input-container>
 
-        <grid-image-selector image="promotion.landingPage.image" label="an image"></grid-image-selector>
-
-        <div layout="column" ng-show="digitalpack">
-            <h5>Subs stripe colour</h5>
-            <md-radio-group layout="row" ng-model="promotion.landingPage.sectionColour">
-                <md-radio-button value="blue" class="md-primary">Blue</md-radio-button>
-                <md-radio-button value="grey">Grey</md-radio-button>
-                <md-radio-button value="white">White</md-radio-button>
-            </md-radio-group>
-        </div>
+        <grid-image-selector ng-show="false" image="promotion.landingPage.image" label="an image"></grid-image-selector>
 
     </div>
 </ng-form>

--- a/frontend/src/templates/PromotionForm.html
+++ b/frontend/src/templates/PromotionForm.html
@@ -13,7 +13,7 @@
                     </div>
                 </md-input-container>
                 <md-input-container class="md-block">
-                    <label>Description (for checkout page summary and product page price card)</label>
+                    <label>Description (for checkout page summary)</label>
                     <input ng-model="promotion.description" name="description" required/>
                     <div ng-messages="promotionForm.description.$error" role="alert">
                         <ng-message when="required">Please enter a description</ng-message>

--- a/frontend/src/templates/PromotionType.html
+++ b/frontend/src/templates/PromotionType.html
@@ -53,11 +53,5 @@
         <!-- Renewal -->
         <md-tab label="Renewal" ng-click="ctrl.setPromotionType('retention')" ng-disabled="coPromotionType === 'retention'">
         </md-tab>
-        <!-- Tracking -->
-        <md-tab label="Tracking" ng-click="ctrl.setPromotionType('tracking')" ng-disabled="coPromotionType">
-            <md-content class="md-padding md-tab-content">
-                <p ng-show="campaignGroup == 'membership'">For Tracking promotions, the <b>Rate plans</b> below are only used to choose the landing page tier.</p>
-            </md-content>
-        </md-tab>
     </md-tabs>
 </ng-form>


### PR DESCRIPTION
* Update sbt repo urls to use https - we were getting warnings that http is deprecated
* Hide the landing page image selector as we don't support setting images via promo codes at the moment
* Remove the landing page colour scheme selectors for DP and GW as we don't support those any more
* Change the descriptions of the various landing page fields to make it clear that the promo code description is used on the checkout only and then repurpose the roundel field for the product page price card text