### PR TITLE
Add new three month fixed rate plan and remove old plans

### DIFF
--- a/app/conf/WeeklyPlans.scala
+++ b/app/conf/WeeklyPlans.scala
@@ -5,19 +5,17 @@ import com.typesafe.config.Config
 import wiring.AppComponents.Stage
 
 case class WeeklyPlans(
-                        zoneA: WeeklySchedules,
-                        zoneB: WeeklySchedules,
-                        zoneC: WeeklySchedules,
-                        domestic: WeeklySchedules,
-                        row: WeeklySchedules
-                      )
+  domestic: WeeklySchedules,
+  row: WeeklySchedules
+)
 
 case class WeeklySchedules(
-                            yearly: ProductRatePlanId,
-                            quarterly: ProductRatePlanId,
-                            six: Option[ProductRatePlanId],
-                            oneYear: Option[ProductRatePlanId]
-                          )
+  yearly: ProductRatePlanId,
+  quarterly: ProductRatePlanId,
+  six: Option[ProductRatePlanId],
+  oneYear: Option[ProductRatePlanId],
+  threeMonth: Option[ProductRatePlanId]
+)
 
 
 object WeeklyPlans {
@@ -28,7 +26,9 @@ object WeeklyPlans {
       six = if (config.hasPath(s"weekly.$product.six"))
         Some(ProductRatePlanId(config.getString(s"weekly.$product.six"))) else None,
       oneYear = if (config.hasPath(s"weekly.$product.oneyear"))
-        Some(ProductRatePlanId(config.getString(s"weekly.$product.oneyear"))) else None
+        Some(ProductRatePlanId(config.getString(s"weekly.$product.oneyear"))) else None,
+      threeMonth = if (config.hasPath(s"weekly.$product.threemonths"))
+        Some(ProductRatePlanId(config.getString(s"weekly.$product.threemonths"))) else None
     )
   }
 
@@ -36,9 +36,6 @@ object WeeklyPlans {
     val c = config.getConfig(s"touchpoint.backend.environments.${stage.name}")
 
     WeeklyPlans(
-      zoneA = plansFor(c, "zoneA"),
-      zoneB = plansFor(c, "zoneB"),
-      zoneC = plansFor(c, "zoneC"),
       domestic = plansFor(c, "domestic"),
       row = plansFor(c, "row")
     )

--- a/app/controllers/RatePlanController.scala
+++ b/app/controllers/RatePlanController.scala
@@ -30,15 +30,15 @@ class RatePlanController(
     EnhancedRatePlan(ratePlan.ratePlanId, ratePlan.ratePlanName, plan.map(_.charges.gbpPrice.prettyAmount), plan.map(_.description), plan.map(_.charges.billingPeriod.monthsInPeriod))
   }
 
-  implicit val prpidWrite = new Writes[ProductRatePlanId] {
+  implicit val prpidWrite: Writes[ProductRatePlanId] = new Writes[ProductRatePlanId] {
     def writes(productRatePlanId: ProductRatePlanId): JsValue = {
       JsString(productRatePlanId.get)
     }
   }
 
 
-  implicit val ratePlanWrite = Json.writes[RatePlan]
-  implicit val eratePlanWrite = Json.writes[EnhancedRatePlan]
+  implicit val ratePlanWrite: OWrites[RatePlan] = Json.writes[RatePlan]
+  implicit val eratePlanWrite: OWrites[EnhancedRatePlan] = Json.writes[EnhancedRatePlan]
 
   lazy val catalog = catalogService.unsafeCatalog
 
@@ -87,28 +87,18 @@ class RatePlanController(
       GuardianWeekly.id -> Json.toJson(
         (
         Seq(
-          RatePlan(weeklyPlans.zoneA.yearly, "Zone A yearly (2017)"),
-          RatePlan(weeklyPlans.zoneA.quarterly, "Zone A quarterly (2017)"),
-          RatePlan(weeklyPlans.zoneB.yearly, "Zone B yearly (2015)"),
-          RatePlan(weeklyPlans.zoneB.quarterly, "Zone B quarterly (2015)"),
-          RatePlan(weeklyPlans.zoneC.yearly, "Zone C yearly (2017)"),
-          RatePlan(weeklyPlans.zoneC.quarterly, "Zone C quarterly (2017)"),
-          RatePlan(weeklyPlans.domestic.yearly, "Domestic yearly (2018)"),
-          RatePlan(weeklyPlans.domestic.quarterly, "Domestic quarterly (2018)"),
-          RatePlan(weeklyPlans.row.yearly, "ROW yearly (2018)"),
-          RatePlan(weeklyPlans.row.quarterly, "ROW quarterly (2018)")
+          RatePlan(weeklyPlans.domestic.yearly, "Domestic Annual"),
+          RatePlan(weeklyPlans.row.yearly, "ROW Annual"),
+          RatePlan(weeklyPlans.domestic.quarterly, "Domestic Quarterly"),
+          RatePlan(weeklyPlans.row.quarterly, "ROW Quarterly")
         )
-          ++ weeklyPlans.domestic.oneYear.map(id => RatePlan(id, "Domestic 1 year (2018)"))
-          ++ weeklyPlans.row.oneYear.map(id => RatePlan(id, "ROW 1 year (2018)"))
-          ++ weeklyPlans.zoneA.six.map(id =>  RatePlan(id, "Zone A 6-for-6 (2017)"))
-          ++ weeklyPlans.zoneC.six.map(id =>  RatePlan(id, "Zone C 6-for-6 (2017)"))
-          ++ weeklyPlans.domestic.six.map(id => RatePlan(id, "6-for-6 Domestic (2018)"))
-          ++ weeklyPlans.row.six.map(id => RatePlan(id, "6-for-6 ROW (2018)"))
-          ++ weeklyPlans.zoneA.oneYear.map(id => RatePlan(id, "Zone A 1 year (Renewal - 2017)"))
-          ++ weeklyPlans.zoneB.oneYear.map(id => RatePlan(id, "Zone B 1 year (Renewal - 2015)"))
-          ++ weeklyPlans.zoneC.oneYear.map(id => RatePlan(id, "Zone C 1 year (Renewal - 2017)"))
+          ++ weeklyPlans.domestic.six.map(id => RatePlan(id, "Domestic 6-for-6"))
+          ++ weeklyPlans.row.six.map(id => RatePlan(id, "ROW 6-for-6"))
+          ++ weeklyPlans.domestic.oneYear.map(id => RatePlan(id, "Domestic 1 year fixed"))
+          ++ weeklyPlans.row.oneYear.map(id => RatePlan(id, "ROW 1 year fixed"))
+          ++ weeklyPlans.domestic.threeMonth.map(id => RatePlan(id, "Domestic 3 month fixed"))
+          ++ weeklyPlans.row.threeMonth.map(id => RatePlan(id, "ROW 3 month fixed"))
         )
-        .sortBy(_.ratePlanName)
         .map(enhance)
       )
     ))

--- a/build.sbt
+++ b/build.sbt
@@ -60,7 +60,7 @@ libraryDependencies ++= Seq(
   cache,
   ws,
   "org.scalaz" %% "scalaz-core" % "7.2.7",
-  "com.gu" %% "membership-common" % "0.549",
+  "com.gu" %% "membership-common" % "0.1-SNAPSHOT",
   "com.gu" %% "play-googleauth" % "0.7.7",
   "com.softwaremill.macwire" %% "macros" % "2.3.1" % "provided",
   "com.softwaremill.macwire" %% "util" % "2.3.1",

--- a/build.sbt
+++ b/build.sbt
@@ -60,7 +60,7 @@ libraryDependencies ++= Seq(
   cache,
   ws,
   "org.scalaz" %% "scalaz-core" % "7.2.7",
-  "com.gu" %% "membership-common" % "0.1-SNAPSHOT",
+  "com.gu" %% "membership-common" % "0.553",
   "com.gu" %% "play-googleauth" % "0.7.7",
   "com.softwaremill.macwire" %% "macros" % "2.3.1" % "provided",
   "com.softwaremill.macwire" %% "util" % "2.3.1",

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -38,34 +38,19 @@ touchpoint.backend.environments {
       saturday="2c92c0f961f9cf300161fc4d2e3e3664"
     }
     weekly {
-      zoneA {
-        yearly="2c92c0f8574b2b8101574c4a9480068d"
-        quarterly="2c92c0f8574b2b8101574c4a957706be"
-        oneyear="2c92c0f958aa455e0158aa6bc72f2aba"
-        six="2c92c0f85a2190ae015a22bbb6194518"
-      }
-      zoneB {
-        yearly="2c92c0f8574b2be601574c39888d6850"
-        quarterly="2c92c0f8574b2be601574c323ca15c7e"
-        oneyear="2c92c0f858aa38af0158b0f0610721d0"
-      }
-      zoneC {
-        yearly="2c92c0f858aa38af0158da325d2f0b3d"
-        quarterly="2c92c0f858aa38af0158da325cec0b2e"
-        oneyear="2c92c0f858aa38af0158da325d790b4b"
-        six="2c92c0f95a246217015a388eaa8c2e2d"
-      }
       domestic {
         yearly="2c92c0f965d280590165f16b1b9946c2"
         quarterly="2c92c0f965dc30640165f150c0956859"
         oneyear="2c92c0f867cae0700167eff921734f7b"
         six="2c92c0f965f212210165f69b94c92d66"
+        threemonths="2c92c0f96ded216a016df491134d4091"
       }
       row {
         yearly="2c92c0f965f2122101660fb33ed24a45"
         quarterly="2c92c0f965f2122101660fb81b745a06"
         oneyear="2c92c0f967caee410167eff78e7b5244"
         six="2c92c0f965f2122101660fbc75a16c38"
+        threemonths="2c92c0f96df75b5a016df81ba1c62609"
       }
     }
 
@@ -96,34 +81,19 @@ touchpoint.backend.environments {
       saturday="2c92c0f85b8fa30e015b9108a83253c7"
     }
     weekly {
-      zoneA {
-        yearly="2c92c0f8574654af015747f934cc4a04"
-        quarterly="2c92c0f9574ee3d80157514ee1c36a8e"
-        oneyear="2c92c0f858aa38ab0158ac0204ce2b56"
-        six="2c92c0f95a246220015a3d680fe1680d"
-      }
-      zoneB {
-        yearly="2c92c0f8574ebcdf015751506d7154ae"
-        quarterly="2c92c0f8574ebcdf015751506daf54c4"
-        oneyear="2c92c0f9585841e7015862c9128e153b"
-      }
-      zoneC {
-        yearly="2c92c0f958aa45650158da23e5eb29d8"
-        quarterly="2c92c0f958aa45650158da23e5ab29c9"
-        oneyear="2c92c0f958aa45650158da23e62d29e7"
-        six="2c92c0f95a24621b015a3d6ce9e32057"
-      }
       domestic {
         yearly="2c92c0f9660fc4d70166107fa5412641"
         quarterly="2c92c0f8660fb5d601661081ea010391"
         oneyear="2c92c0f867cae0700167f043870d6d0e"
         six="2c92c0f8660fb5dd016610858eb90658"
+        threemonths="2c92c0f96df75b51016df8444f36362f"
       }
       row {
         yearly="2c92c0f9660fc4d70166109a2eb0607c"
         quarterly="2c92c0f9660fc4d70166109c01465f10"
         oneyear="2c92c0f967caee360167f044cd0d4adc"
         six="2c92c0f9660fc4c70166109dfd08092c"
+        threemonths="2c92c0f96df75b5a016df84084fb356d"
       }
 
     }
@@ -155,34 +125,19 @@ touchpoint.backend.environments {
       saturday="2c92a0fd5e1dcf0d015e3cb39d0a7ddb"
     }
     weekly {
-      zoneA {
-        yearly="2c92a0ff57d0a0b60157d741e722439a"
-        quarterly="2c92a0fd57d0a9870157d7412f19424f"
-        oneyear="2c92a0ff58bdf4eb0158f2ecc89c1034"
-        six="2c92a0ff59d9d540015a41a40b3e07d3"
-      }
-      zoneB {
-        yearly="2c92a0fe57d0a0c40157d74240de5543"
-        quarterly="2c92a0fe57d0a0c40157d74241005544"
-        oneyear="2c92a0fd58cf57000158f30ae6d06f2a"
-      }
-      zoneC {
-        oneyear="2c92a0ff58bdf4ee0158f30905e82181"
-        yearly="2c92a0ff58bdf4eb0158f307eccf02af"
-        quarterly="2c92a0ff58bdf4eb0158f307ed0e02be"
-        six="2c92a0fc5a2a49f0015a41f473da233a"
-      }
       domestic {
         oneyear="2c92a0ff67cebd0d0167f0a1a834234e"
         yearly="2c92a0fe6619b4b901661aa8e66c1692"
         quarterly="2c92a0fe6619b4b301661aa494392ee2"
         six="2c92a0086619bf8901661aaac94257fe"
+        threemonths="2c92a00e6dd988e2016df85387417498"
       }
       row {
         oneyear="2c92a0ff67cebd140167f0a2f66a12eb"
         yearly="2c92a0fe6619b4b601661ab300222651"
         quarterly="2c92a0086619bf8901661ab02752722f"
         six="2c92a0086619bf8901661ab545f51b21"
+        threemonths="2c92a0076dd9892e016df8503e7c6c48"
       }
     }
   }


### PR DESCRIPTION
We have a new fixed term rate plan for Guardian Weekly, this PR makes the promo code tool aware of it.

I have also removed the old Guardian Weekly rate plans as we are no longer selling them and simplified the way the rate plans are displayed in the UI

## The old rate plan layout:
![Screen Shot 2019-11-14 at 15 42 08](https://user-images.githubusercontent.com/181371/68872144-751fe480-06f5-11ea-9c6f-299e2b5de7da.png)
## The new layout:
![Screen Shot 2019-11-14 at 15 42 25](https://user-images.githubusercontent.com/181371/68872146-75b87b00-06f5-11ea-86e3-e851a7095439.png)

