### PR TITLE
Update label for the 'description' field

### DIFF
--- a/frontend/src/templates/PromotionForm.html
+++ b/frontend/src/templates/PromotionForm.html
@@ -13,7 +13,7 @@
                     </div>
                 </md-input-container>
                 <md-input-container class="md-block">
-                    <label>Description for checkout page summary</label>
+                    <label>Description for checkout page summary and showcase page promotional copy</label>
                     <input ng-model="promotion.description" name="description" required/>
                     <div ng-messages="promotionForm.description.$error" role="alert">
                         <ng-message when="required">Please enter a description</ng-message>


### PR DESCRIPTION
Update the label for the 'description' field to reflect the fact that it is now used on the showcase page as well as the checkout.