### PR TITLE
Multi currency discounts

### DIFF
--- a/app/controllers/RatePlanController.scala
+++ b/app/controllers/RatePlanController.scala
@@ -2,14 +2,22 @@ package controllers
 
 import actions.GoogleAuthAction.GoogleAuthenticatedAction
 import com.gu.config.{DigitalPackRatePlanIds, MembershipRatePlanIds}
+import com.gu.i18n.Currency
+import com.gu.memsub.Price
 import com.gu.memsub.Subscription.ProductRatePlanId
-import com.gu.memsub.promo.CampaignGroup.{DigitalPack, GuardianWeekly, Membership, Newspaper}
+import com.gu.memsub.promo.CampaignGroup.{DigitalPack, GuardianWeekly, Newspaper}
 import com.gu.memsub.subsv2.services.CatalogService
+import com.typesafe.scalalogging.LazyLogging
 import conf.{PaperProducts, WeeklyPlans}
+import controllers.RatePlanController._
 import play.api.libs.json._
 import play.api.mvc.Results._
 
 import scala.concurrent.Future
+
+case class RatePlan(ratePlanId: ProductRatePlanId, ratePlanName: String)
+
+case class EnhancedRatePlan(ratePlanId: ProductRatePlanId, ratePlanName: String, price: Option[String], priceSummary: Option[Map[Currency, Price]], description: Option[String],period:Option[Int])
 
 class RatePlanController(
 
@@ -21,24 +29,18 @@ class RatePlanController(
                           catalogService: CatalogService[Future]
                         ) {
 
-  case class RatePlan(ratePlanId: ProductRatePlanId, ratePlanName: String)
-
-  case class EnhancedRatePlan(ratePlanId: ProductRatePlanId, ratePlanName: String, price: Option[String],description: Option[String],period:Option[Int])
-
   def enhance(ratePlan: RatePlan): EnhancedRatePlan = {
     val plan = find(ratePlan.ratePlanId)
-    EnhancedRatePlan(ratePlan.ratePlanId, ratePlan.ratePlanName, plan.map(_.charges.gbpPrice.prettyAmount), plan.map(_.description), plan.map(_.charges.billingPeriod.monthsInPeriod))
+    EnhancedRatePlan(
+      ratePlan.ratePlanId,
+      ratePlan.ratePlanName,
+      plan.map(_.charges.gbpPrice.prettyAmount),
+      plan.map(_.charges.price.underlying),
+      plan.map(_.description),
+      plan.map(_.charges.billingPeriod.monthsInPeriod)
+    )
   }
 
-  implicit val prpidWrite: Writes[ProductRatePlanId] = new Writes[ProductRatePlanId] {
-    def writes(productRatePlanId: ProductRatePlanId): JsValue = {
-      JsString(productRatePlanId.get)
-    }
-  }
-
-
-  implicit val ratePlanWrite: OWrites[RatePlan] = Json.writes[RatePlan]
-  implicit val eratePlanWrite: OWrites[EnhancedRatePlan] = Json.writes[EnhancedRatePlan]
 
   lazy val catalog = catalogService.unsafeCatalog
 
@@ -48,15 +50,6 @@ class RatePlanController(
 
   def all = googleAuthAction {
     Ok(Json.obj(
-      Membership.id -> Json.toJson(Seq(
-        RatePlan(membershipIds.friend, "Friend"),
-        RatePlan(membershipIds.supporterMonthly, "Supporter monthly"),
-        RatePlan(membershipIds.supporterYearly, "Supporter yearly"),
-        RatePlan(membershipIds.partnerMonthly, "Partner monthly"),
-        RatePlan(membershipIds.partnerYearly, "Partner yearly"),
-        RatePlan(membershipIds.patronMonthly, "Patron monthly"),
-        RatePlan(membershipIds.patronYearly, "Patron yearly")
-      ).map(enhance)),
       DigitalPack.id -> Json.toJson(Seq(
         RatePlan(digipackIds.digitalPackMonthly, "Digital Pack monthly"),
         RatePlan(digipackIds.digitalPackQuaterly, "Digital Pack quarterly"),
@@ -103,4 +96,12 @@ class RatePlanController(
       )
     ))
   }
+}
+
+object RatePlanController {
+  implicit val prpidWrite: Writes[ProductRatePlanId] = (productRatePlanId: ProductRatePlanId) => JsString(productRatePlanId.get)
+  implicit val ratePlanWrite: OWrites[RatePlan] = Json.writes[RatePlan]
+  implicit val priceWrite: Writes[Price] = (price: Price) => JsString(price.amount.toString)
+  implicit val currencyWrite: Writes[Currency] = (currency: Currency) => JsString(currency.iso)
+  implicit val eratePlanWrite: OWrites[EnhancedRatePlan] = Json.writes[EnhancedRatePlan]
 }

--- a/app/controllers/RatePlanController.scala
+++ b/app/controllers/RatePlanController.scala
@@ -3,6 +3,7 @@ package controllers
 import actions.GoogleAuthAction.GoogleAuthenticatedAction
 import com.gu.config.{DigitalPackRatePlanIds, MembershipRatePlanIds}
 import com.gu.i18n.Currency
+import com.gu.i18n.Currency.{AUD, CAD, EUR, GBP, USD}
 import com.gu.memsub.Price
 import com.gu.memsub.Subscription.ProductRatePlanId
 import com.gu.memsub.promo.CampaignGroup.{DigitalPack, GuardianWeekly, Newspaper}
@@ -28,13 +29,22 @@ class RatePlanController(
     catalogService: CatalogService[Future]
   ) {
 
+  def sortCurrency = (price: Price) => price.currency match {
+    case GBP => 0
+    case USD => 1
+    case AUD => 2
+    case EUR => 3
+    case CAD => 4
+    case _ => 5
+  }
+
   def enhance(ratePlan: RatePlan): EnhancedRatePlan = {
     val plan = find(ratePlan.ratePlanId)
     EnhancedRatePlan(
       ratePlan.ratePlanId,
       ratePlan.ratePlanName,
       plan.map(_.charges.gbpPrice.prettyAmount),
-      plan.map(_.charges.price.prices),
+      plan.map(_.charges.price.prices.toList.sortBy(sortCurrency)),
       plan.map(_.description),
       plan.map(_.charges.billingPeriod.monthsInPeriod)
     )

--- a/frontend/scss/main.scss
+++ b/frontend/scss/main.scss
@@ -179,3 +179,7 @@ s {
 .half-width {
   width: 45%;
 }
+
+.full-width {
+  width: 90%;
+}

--- a/frontend/scss/main.scss
+++ b/frontend/scss/main.scss
@@ -180,6 +180,16 @@ s {
   width: 45%;
 }
 
-.full-width {
-  width: 90%;
+.discount-list {
+  padding-top: 8px;
 }
+
+.rate-plan-list {
+  md-checkbox {
+    margin-right: 25px;
+  }
+  md-checkbox .md-container {
+    top: 5%;
+  }
+}
+

--- a/frontend/src/controllers/RatePlanListController.es6
+++ b/frontend/src/controllers/RatePlanListController.es6
@@ -5,13 +5,13 @@ export default class {
         this.$scope = $scope;
         this.ratePlans = ratePlanService.all();
         this.ratePlans.then(plans => $scope.ratePlans = plans);
-        $scope.discountedPrice = (plan)=> {
+        $scope.discountedPrice = (period, amount)=> {
            //https://github.com/guardian/membership-common/blob/0cb919ea78a56e8307d51863d33788d46bd78ebd/src/main/scala/com/gu/memsub/promo/Promotion.scala#L270-L270
-            let periodRatio = $scope.length?parseFloat($scope.length)/parseFloat(plan.period):1;
+            let periodRatio = $scope.length?parseFloat($scope.length)/parseFloat(period):1;
             let numberOfNewPeriods = Math.ceil(periodRatio);
             let newDiscountPercent = ($scope.discount * periodRatio) / numberOfNewPeriods;
 
-            return plan.price * (1-newDiscountPercent/100);
+            return amount * (1-newDiscountPercent/100);
 
         };
         $scope.showDiscountWarning = (plan) => {

--- a/frontend/src/templates/PromotionForm.html
+++ b/frontend/src/templates/PromotionForm.html
@@ -20,7 +20,12 @@
                     </div>
                 </md-input-container>
                 <multi-promotion-type promotion="promotion" campaign-group="campaignGroup"></multi-promotion-type>
-                <rate-plan-list product-rate-plan-ids="promotion.appliesTo.productRatePlanIds" campaign-group="campaignGroup" discount="promotion.promotionType.amount || promotion.promotionType.a.amount || promotion.promotionType.b.amount" length="promotion.promotionType.durationMonths || promotion.promotionType.a.durationMonths || promotion.promotionType.b.durationMonths"></rate-plan-list>
+                <rate-plan-list
+                        product-rate-plan-ids="promotion.appliesTo.productRatePlanIds"
+                        campaign-group="campaignGroup"
+                        discount="promotion.promotionType.amount || promotion.promotionType.a.amount || promotion.promotionType.b.amount"
+                        length="promotion.promotionType.durationMonths || promotion.promotionType.a.durationMonths || promotion.promotionType.b.durationMonths">
+                </rate-plan-list>
                 <available-countries countries="promotion.appliesTo.countries"></available-countries>
                 <promotion-dates promotion="promotion"></promotion-dates>
                 <channel-codes codes="promotion.codes"></channel-codes>

--- a/frontend/src/templates/PromotionForm.html
+++ b/frontend/src/templates/PromotionForm.html
@@ -49,5 +49,5 @@
             </div>
         </form>
     </div>
-    <preview-promotion ng-show="campaignGroup !== 'membership' && promotion.landingPage !== undefined" flex layout="column" promotion="promotion" validity="promotionForm.$valid"></preview-promotion>
+    <preview-promotion ng-show="false" flex layout="column" promotion="promotion" validity="promotionForm.$valid"></preview-promotion>
 </div>

--- a/frontend/src/templates/RatePlanList.html
+++ b/frontend/src/templates/RatePlanList.html
@@ -1,23 +1,24 @@
 <div layout="column" ng-repeat="(planKey, plans) in ratePlans" ng-show="planKey == campaignGroup">
   <h5>Rate plans</h5>
-  <div>
+  <div class="rate-plan-list">
     <md-checkbox ng-model="ratePlanIds[plan.ratePlanId]" aria-label="{{plan.ratePlanName}}"
                  ng-repeat="plan in plans"
                  ng-change="ctrl.applyRatePlans(ratePlanIds)"
-                 class="full-width"0
     >
       {{plan.ratePlanName}}
-      <div
-              ng-if="discount && plan.priceSummary"
-              ng-repeat="price in plan.priceSummary"
-      >
-        <s>{{price.amount | currency: price.currency + " " }} </s>
-        <md-icon md-font-set="material-icons">arrow_forward</md-icon>
-        <strong>{{discountedPrice(plan.period, price.amount) | currency: price.currency + " " }}</strong>
-        <span ng-show="showDiscountWarning(plan)">
-          <md-tooltip>The promotion is not a whole number of billing periods. The discount will be evenly spread over at least one complete billing period.</md-tooltip>
-          <md-icon md-font-set="material-icons">warning</md-icon>
-        </span>
+      <div class="discount-list">
+        <div
+                ng-if="discount && plan.priceSummary"
+                ng-repeat="price in plan.priceSummary"
+        >
+          <s>{{price.amount | currency: price.currency + " " }} </s>
+          <md-icon md-font-set="material-icons">arrow_forward</md-icon>
+          <strong>{{discountedPrice(plan.period, price.amount) | currency: price.currency + " " }}</strong>
+          <span ng-show="showDiscountWarning(plan)">
+            <md-tooltip>The promotion is not a whole number of billing periods. The discount will be evenly spread over at least one complete billing period.</md-tooltip>
+            <md-icon md-font-set="material-icons">warning</md-icon>
+          </span>
+        </div>
       </div>
     </md-checkbox>
   </div>

--- a/frontend/src/templates/RatePlanList.html
+++ b/frontend/src/templates/RatePlanList.html
@@ -4,18 +4,21 @@
     <md-checkbox ng-model="ratePlanIds[plan.ratePlanId]" aria-label="{{plan.ratePlanName}}"
                  ng-repeat="plan in plans"
                  ng-change="ctrl.applyRatePlans(ratePlanIds)"
-                 class="half-width"
+                 class="full-width"0
     >
       {{plan.ratePlanName}}
-      <span ng-if="discount && plan.price">
-        <s>{{plan.price | currency:"£" }} </s>
+      <div
+              ng-if="discount && plan.priceSummary"
+              ng-repeat="price in plan.priceSummary"
+      >
+        <s>{{price.amount | currency: price.currency + " " }} </s>
         <md-icon md-font-set="material-icons">arrow_forward</md-icon>
-        <strong>{{discountedPrice(plan) | currency:"£" }}</strong>
+        <strong>{{discountedPrice(plan.period, price.amount) | currency: price.currency + " " }}</strong>
         <span ng-show="showDiscountWarning(plan)">
           <md-tooltip>The promotion is not a whole number of billing periods. The discount will be evenly spread over at least one complete billing period.</md-tooltip>
           <md-icon md-font-set="material-icons">warning</md-icon>
         </span>
-      </span>
+      </div>
     </md-checkbox>
   </div>
 </div>

--- a/test/ratePlans/RatePlanControllerSpec.scala
+++ b/test/ratePlans/RatePlanControllerSpec.scala
@@ -18,13 +18,28 @@ class RatePlanControllerSpec extends PlaySpec {
         ProductRatePlanId("blah"),
         "Test plan",
         Some("19"),
-        Some(Map(GBP -> price)),
+        Some(List(price)),
         Some("description"),
         Some(3)
       )
       val json = Json.toJson(erp)
 
-      val expected = Json.parse("{\"ratePlanId\":\"blah\",\"ratePlanName\":\"Test plan\",\"price\":\"19\",\"priceSummary\":[[\"GBP\",\"19.0\"]],\"description\":\"description\",\"period\":3}")
+      val expected = Json.parse(
+        """
+          {
+              "ratePlanId": "blah",
+              "ratePlanName": "Test plan",
+              "price": "19",
+              "priceSummary": [
+                  {
+                      "currency": "GBP",
+                      "amount": "19.0"
+                  }
+              ],
+              "description": "description",
+              "period": 3
+          }
+        """)
       json mustBe expected
     }
   }

--- a/test/ratePlans/RatePlanControllerSpec.scala
+++ b/test/ratePlans/RatePlanControllerSpec.scala
@@ -1,0 +1,31 @@
+package ratePlans
+
+import com.gu.i18n.Currency.GBP
+import com.gu.memsub.Price
+import com.gu.memsub.Subscription.ProductRatePlanId
+import controllers.EnhancedRatePlan
+import controllers.RatePlanController._
+import org.scalatestplus.play.PlaySpec
+import play.api.libs.json.Json
+
+class RatePlanControllerSpec extends PlaySpec {
+
+  "RatePlanController" must {
+    "serialise rate plans" in {
+      val price = Price(19F, GBP)
+
+      val erp = EnhancedRatePlan(
+        ProductRatePlanId("blah"),
+        "Test plan",
+        Some("19"),
+        Some(Map(GBP -> price)),
+        Some("description"),
+        Some(3)
+      )
+      val json = Json.toJson(erp)
+
+      val expected = Json.parse("{\"ratePlanId\":\"blah\",\"ratePlanName\":\"Test plan\",\"price\":\"19\",\"priceSummary\":[[\"GBP\",\"19.0\"]],\"description\":\"description\",\"period\":3}")
+      json mustBe expected
+    }
+  }
+}


### PR DESCRIPTION
## What is this change
Currently the promotion form only shows pricing information for GBP prices which makes it very hard to work out the correct discount amounts for other currencies. 
This PR adds in pricing in all other currencies which we support.

## Screenshot

<img width="814" alt="Screen Shot 2020-04-09 at 15 53 37" src="https://user-images.githubusercontent.com/181371/78908979-c355cb80-7a7a-11ea-96d8-1066f26d3034.png">
