### PR TITLE
add fields to newspaper landing page section in the promo tool

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -62,7 +62,7 @@ libraryDependencies ++= Seq(
   cache,
   ws,
   "org.scalaz" %% "scalaz-core" % "7.2.7",
-  "com.gu" %% "membership-common" % "0.589",
+  "com.gu" %% "membership-common" % "0.1-SNAPSHOT",
   "com.gu.play-googleauth" %% "play-v27" % "1.0.7",
   "com.softwaremill.macwire" %% "macros" % "2.3.1" % "provided",
   "com.softwaremill.macwire" %% "util" % "2.3.1",

--- a/build.sbt
+++ b/build.sbt
@@ -62,7 +62,7 @@ libraryDependencies ++= Seq(
   cache,
   ws,
   "org.scalaz" %% "scalaz-core" % "7.2.7",
-  "com.gu" %% "membership-common" % "0.1-SNAPSHOT",
+  "com.gu" %% "membership-common" % "0.594",
   "com.gu.play-googleauth" %% "play-v27" % "1.0.7",
   "com.softwaremill.macwire" %% "macros" % "2.3.1" % "provided",
   "com.softwaremill.macwire" %% "util" % "2.3.1",

--- a/frontend/src/templates/LandingPage.html
+++ b/frontend/src/templates/LandingPage.html
@@ -5,19 +5,7 @@
         This promotion has a landing page
     </md-checkbox>
 
-    <div layout="column" ng-show="promotion.landingPage !== undefined" ng-if="newspaper">
-        <md-input-container>
-            <label>Description</label>
-            <textarea name="landing-description" ng-model="promotion.landingPage.description" delete-empty></textarea>
-        </md-input-container>
-        <h5>Default product</h5>
-        <md-radio-group layout="row" ng-model="promotion.landingPage.defaultProduct">
-            <md-radio-button value="voucher" class="md-primary" ng-checked="true">Voucher</md-radio-button>
-            <md-radio-button value="delivery">Home Delivery</md-radio-button>
-        </md-radio-group>
-    </div>
-
-    <div layout="column" ng-show="promotion.landingPage !== undefined" ng-if="!newspaper">
+    <div layout="column" ng-show="promotion.landingPage !== undefined">
         <grid-image-selector image="promotion.landingPage.heroImage.image" label="a hero image" ng-if="membership" change="ctrl.heroImageChange(promotion.landingpage.heroImage.alignment)"></grid-image-selector>
         <div layout="column" ng-show="membership && promotion.landingPage.heroImage !== undefined">
             <h5>Hero image alignment</h5>


### PR DESCRIPTION
This PR adds the new fields to the promo tool so that paper can have copy editing in more places on the landing page

https://trello.com/c/rdC88F6V/3593-add-fields-to-promo-code-tool-to-enable-print-landing-page-input

old
https://memsub-promotions.gutools.co.uk/#/promotion/39ddaac7-5a5e-4b77-b004-2a60749ebdce
![image](https://user-images.githubusercontent.com/7304387/111172514-cc5def80-859d-11eb-81f5-b30c1f3acf2d.png)

new
![image](https://user-images.githubusercontent.com/7304387/111172384-af292100-859d-11eb-888f-0ad754bbe128.png)

and the result (example copy)
![image](https://user-images.githubusercontent.com/7304387/111172861-1646d580-859e-11eb-9658-5bcc0dea0df6.png)
