### PR TITLE
Add default product radio buttons back into the newspaper form

### DIFF
--- a/frontend/src/templates/LandingPage.html
+++ b/frontend/src/templates/LandingPage.html
@@ -5,6 +5,14 @@
         This promotion has a landing page
     </md-checkbox>
 
+    <div layout="column" ng-show="promotion.landingPage !== undefined" ng-if="newspaper">
+        <h5>Default product</h5>
+        <md-radio-group layout="row" ng-model="promotion.landingPage.defaultProduct">
+            <md-radio-button value="voucher" class="md-primary" ng-checked="true">Voucher</md-radio-button>
+            <md-radio-button value="delivery">Home Delivery</md-radio-button>
+        </md-radio-group>
+    </div>
+
     <div layout="column" ng-show="promotion.landingPage !== undefined">
         <grid-image-selector image="promotion.landingPage.heroImage.image" label="a hero image" ng-if="membership" change="ctrl.heroImageChange(promotion.landingpage.heroImage.alignment)"></grid-image-selector>
         <div layout="column" ng-show="membership && promotion.landingPage.heroImage !== undefined">


### PR DESCRIPTION
## What does this change?
#189 removed the radio buttons which set the default product for a newspaper promotion. This made sense because they are not used by support-frontend currently however it broke deserialisation of new promotions in the `PromotionController` class because the `NewsPaperLandingPage` case class defined in membership-common expects a value for `defaultProduct`

This PR adds those fields back in.

[**Trello Card**](https://trello.com/c/f05ZuVWs/3676-fix-newspaper-promotion-creation-in-promo-code-tool)