### PR TITLE
Add subscription card (digitalVoucher) into the PaperPlans

### DIFF
--- a/app/conf/PaperPlans.scala
+++ b/app/conf/PaperPlans.scala
@@ -4,6 +4,7 @@ import com.typesafe.config.Config
 import wiring.AppComponents.Stage
 
 case class PaperProducts(
+  digitalVoucher: PaperPlans,
   voucher: PaperPlans,
   delivery: PaperPlans
 )
@@ -40,6 +41,7 @@ object PaperProducts {
     val c = config.getConfig(s"touchpoint.backend.environments.${stage.name}")
 
     PaperProducts(
+      digitalVoucher = plansFor(c, "digitalVoucher"),
       voucher = plansFor(c, "voucher"),
       delivery = plansFor(c, "delivery")
     )

--- a/app/controllers/RatePlanController.scala
+++ b/app/controllers/RatePlanController.scala
@@ -65,8 +65,6 @@ class RatePlanController(
         RatePlan(digipackIds.digitalPackYearly, "Digital Pack yearly")
       ).map(enhance)),
       Newspaper.id -> Json.toJson(Seq(
-        RatePlan(paperPlans.delivery.saturday, "Home Delivery Saturday"),
-        RatePlan(paperPlans.delivery.saturdayplus, "Home Delivery Saturday+"),
         RatePlan(paperPlans.delivery.sunday, "Home Delivery Sunday"),
         RatePlan(paperPlans.delivery.sundayplus, "Home Delivery Sunday+"),
         RatePlan(paperPlans.delivery.weekend, "Home Delivery Weekend"),
@@ -75,8 +73,6 @@ class RatePlanController(
         RatePlan(paperPlans.delivery.sixdayplus, "Home Delivery Sixday+"),
         RatePlan(paperPlans.delivery.everyday, "Home Delivery Everyday"),
         RatePlan(paperPlans.delivery.everydayplus, "Home Delivery Everyday+"),
-        RatePlan(paperPlans.voucher.saturday, "Voucher Saturday"),
-        RatePlan(paperPlans.voucher.saturdayplus, "Voucher Saturday+"),
         RatePlan(paperPlans.voucher.sunday, "Voucher Sunday"),
         RatePlan(paperPlans.voucher.sundayplus, "Voucher Sunday+"),
         RatePlan(paperPlans.voucher.weekend, "Voucher Weekend"),
@@ -84,7 +80,15 @@ class RatePlanController(
         RatePlan(paperPlans.voucher.sixday, "Voucher Sixday"),
         RatePlan(paperPlans.voucher.sixdayplus, "Voucher Sixday+"),
         RatePlan(paperPlans.voucher.everyday, "Voucher Everyday"),
-        RatePlan(paperPlans.voucher.everydayplus, "Voucher Everyday+")
+        RatePlan(paperPlans.voucher.everydayplus, "Voucher Everyday+"),
+        RatePlan(paperPlans.digitalVoucher.sunday, "Subscription Card Sunday"),
+        RatePlan(paperPlans.digitalVoucher.sundayplus, "Subscription Card Sunday+"),
+        RatePlan(paperPlans.digitalVoucher.weekend, "Subscription Card Weekend"),
+        RatePlan(paperPlans.digitalVoucher.weekendplus, "Subscription Card Weekend+"),
+        RatePlan(paperPlans.digitalVoucher.sixday, "Subscription Card Sixday"),
+        RatePlan(paperPlans.digitalVoucher.sixdayplus, "Subscription Card Sixday+"),
+        RatePlan(paperPlans.digitalVoucher.everyday, "Subscription Card Everyday"),
+        RatePlan(paperPlans.digitalVoucher.everydayplus, "Subscription Card Everyday+")
       ).map(enhance)),
       GuardianWeekly.id -> Json.toJson(
         (

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -13,6 +13,18 @@ play.http {
 
 touchpoint.backend.environments {
   DEV {
+    digitalVoucher {
+      everydayplus="2c92c0f86fa49142016fa49eaa492988"
+      everyday="2c92c0f86fa49142016fa49ea56a2938"
+      sixdayplus="2c92c0f86fa49142016fa49ea1af28c8"
+      sixday="2c92c0f86fa49142016fa49e9b9a286f"
+      weekendplus="2c92c0f86fa49142016fa49eaecb29dd"
+      weekend="2c92c0f86fa49142016fa49ea0d028b6"
+      sundayplus="2c92c0f86fa49142016fa49ea90e2976"
+      sunday="2c92c0f86fa49142016fa49eb0a42a01"
+      saturdayplus="2c92c0f86fa49142016fa49eb1732a39"
+      saturday="2c92c0f86fa49142016fa49ea442291b"
+    }
     voucher {
       everydayplus="2c92c0f95aff3b53015b10469bbf5f5f"
       everyday="2c92c0f9555cf10501556e84a70440e2"
@@ -56,6 +68,18 @@ touchpoint.backend.environments {
 
   }
   UAT {
+    digitalVoucher {
+      everydayplus="2c92c0f870f682820171070481bf4264"
+      everyday="2c92c0f870f682820171070474ee419d"
+      sixdayplus="2c92c0f870f682820171070470ad4120"
+      sixday="2c92c0f870f68282017107047d054230"
+      weekendplus="2c92c0f870f682820171070478d441f5"
+      weekend="2c92c0f870f682820171070477d841e2"
+      sundayplus="2c92c0f870f68282017107047b214214"
+      sunday="2c92c0f870f682820171070487f142c4"
+      saturdayplus="2c92c0f870f682820171070489d542da"
+      saturday="2c92c0f870f682820171070488df42ce"
+    }
     voucher {
       everydayplus="2c92c0f955ca02920155da240cdb4399"
       everyday="2c92c0f855c9f4b20155d9f1d3d4512a"
@@ -100,6 +124,18 @@ touchpoint.backend.environments {
 
   }
   PROD {
+    digitalVoucher {
+      everydayplus="2c92a00870ec598001710740d3d03035"
+      everyday="2c92a00870ec598001710740c78d2f13"
+      sixdayplus="2c92a00870ec598001710740c4582ead"
+      sixday="2c92a00870ec598001710740ca532f69"
+      weekendplus="2c92a00870ec598001710740c6672ee7"
+      weekend="2c92a00870ec598001710740d24b3022"
+      sundayplus="2c92a00870ec598001710740cf9e3004"
+      sunday="2c92a00870ec598001710740d0d83017"
+      saturdayplus="2c92a00870ec598001710740ce702ff0"
+      saturday="2c92a00870ec598001710740cdd02fbd"
+    }
     voucher {
       everydayplus="2c92a0ff56fe33f50157040bbdcf3ae4"
       everyday="2c92a0fd56fe270b0157040dd79b35da"


### PR DESCRIPTION
## What does this change?
This PR adds subscription card (digital voucher) into the list of newspaper products which we can offer discounts on.

This is the only type of voucher product which is sold via support.theguardian.com now so we need to be able to apply promotions to it. 

I have left the old voucher product in place as this is still sold by CSRs through the legacy subscribe site.

