### PR TITLE
Add a Github action for Snyk integration

### DIFF
--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -19,11 +19,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Set command to monitor
-        if:
-          contains('
-            refs/heads/main
-            refs/heads/snyk-action
-          ', github.ref)
+        if: github.ref == 'refs/heads/main'
         run: echo "SNYK_COMMAND=monitor" >> $GITHUB_ENV
 
       - name: Run Snyk to check for Node vulnerabilities

--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -1,0 +1,51 @@
+# This action runs every day at 6 AM and on every push
+# If the branch it's running on is main then it will run snyk monitor (reports vulnerabilities to snyk.io)
+# Otherwise it will run snyk test
+name: Snyk
+
+on:
+  schedule:
+    - cron: "0 6 * * *"
+  push:
+  workflow_dispatch:
+
+jobs:
+  security:
+    runs-on: ubuntu-latest
+    env:
+      SNYK_COMMAND: test
+    steps:
+      - name: Checkout branch
+        uses: actions/checkout@v2
+
+      - name: Set command to monitor
+        if:
+          contains('
+            refs/heads/main
+            refs/heads/snyk-action
+          ', github.ref)
+        run: echo "SNYK_COMMAND=monitor" >> $GITHUB_ENV
+
+      - name: Run Snyk to check for Node vulnerabilities
+        uses: snyk/actions/node@0.3.0
+        env:
+          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+        with:
+          args: --org=the-guardian-cuu --project-name=memsub-promotions-node --file=./frontend/yarn.lock
+          command: ${{ env.SNYK_COMMAND }}
+
+      - name: Run Snyk to check for Scala vulnerabilities
+        uses: snyk/actions/scala@0.3.0
+        env:
+          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+        with:
+          args: --org=the-guardian-cuu --project-name=memsub-promotions-sbt
+          command: ${{ env.SNYK_COMMAND }}
+
+      - name: Run Snyk to check for vulnerabilities in the lambdas
+        uses: snyk/actions/node@0.3.0
+        env:
+          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+        with:
+          args: --org=the-guardian-cuu --project-name=memsub-promotions-lambdas --file=./lambdas/yarn.lock
+          command: ${{ env.SNYK_COMMAND }}


### PR DESCRIPTION
## What does this change?
The currently recommended way of integrating [Snyk](https://app.snyk.io/org/the-guardian-cuu/) with a repository is to use Github actions as described in [this doc](https://github.com/guardian/security-hq/blob/main/hq/markdown/snyk.md#integrating-snyk-with-your-projects)

This PR adds an action to handle Snyk integration. I have also disabled the TeamCity build step which was previously managing the integration.
