### PR TITLE
stop snyk finding lots of random files to scan

### DIFF
--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -4,9 +4,10 @@
 name: Snyk
 
 on:
-  schedule:
-    - cron: "0 6 * * *"
   push:
+    branches:
+      - main
+      - jd-snyk-fix
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -1,6 +1,3 @@
-# This action runs every day at 6 AM and on every push
-# If the branch it's running on is main then it will run snyk monitor (reports vulnerabilities to snyk.io)
-# Otherwise it will run snyk test
 name: Snyk
 
 on:
@@ -13,15 +10,9 @@ on:
 jobs:
   security:
     runs-on: ubuntu-latest
-    env:
-      SNYK_COMMAND: test
     steps:
       - name: Checkout branch
         uses: actions/checkout@v2
-
-      - name: Set command to monitor
-        if: github.ref == 'refs/heads/main'
-        run: echo "SNYK_COMMAND=monitor" >> $GITHUB_ENV
 
       - name: Run Snyk to check for Node vulnerabilities
         uses: snyk/actions/node@0.3.0
@@ -29,7 +20,7 @@ jobs:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
         with:
           args: --org=the-guardian-cuu --project-name=memsub-promotions-node --file=./frontend/yarn.lock
-          command: ${{ env.SNYK_COMMAND }}
+          command: monitor
 
       - name: Run Snyk to check for Scala vulnerabilities
         uses: snyk/actions/scala@0.3.0
@@ -37,7 +28,7 @@ jobs:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
         with:
           args: --org=the-guardian-cuu --project-name=memsub-promotions-sbt --file=./build.sbt
-          command: ${{ env.SNYK_COMMAND }}
+          command: monitor
 
       - name: Run Snyk to check for vulnerabilities in the lambdas
         uses: snyk/actions/node@0.3.0
@@ -45,4 +36,4 @@ jobs:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
         with:
           args: --org=the-guardian-cuu --project-name=memsub-promotions-lambdas --file=./lambdas/yarn.lock
-          command: ${{ env.SNYK_COMMAND }}
+          command: monitor

--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -35,7 +35,7 @@ jobs:
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
         with:
-          args: --org=the-guardian-cuu --project-name=memsub-promotions-sbt
+          args: --org=the-guardian-cuu --project-name=memsub-promotions-sbt --file=./build.sbt
           command: ${{ env.SNYK_COMMAND }}
 
       - name: Run Snyk to check for vulnerabilities in the lambdas


### PR DESCRIPTION
This PR makes snyk focus on the root build.sbt file, rather than going through the whole repo and making loads of "projects"

It also makes it run on a merge to main, rather than waiting until the next day.  This should use less resources and also get the results in the dashbord quicker.