### PR TITLE
java 11

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -42,11 +42,9 @@ riffRaffArtifactResources += (file("cloudformation/memsub-promotions-cf.yaml"), 
 
 javaOptions in Universal ++= Seq(
   "-Dpidfile.path=/dev/null",
-  "-J-XX:MaxRAMFraction=2",
-  "-J-XX:InitialRAMFraction=2",
   "-J-XX:MaxMetaspaceSize=500m",
   "-J-XX:+PrintGCDetails",
-  s"-J-Xloggc:/var/log/${packageName.value}/gc.log"
+  s"-J-Xlog:gc:/var/log/${packageName.value}/gc.log"
 )
 
 scalaVersion := "2.13.7"

--- a/build.sbt
+++ b/build.sbt
@@ -46,7 +46,6 @@ javaOptions in Universal ++= Seq(
   "-J-XX:InitialRAMFraction=2",
   "-J-XX:MaxMetaspaceSize=500m",
   "-J-XX:+PrintGCDetails",
-  "-J-XX:+PrintGCDateStamps",
   s"-J-Xloggc:/var/log/${packageName.value}/gc.log"
 )
 

--- a/build.sbt
+++ b/build.sbt
@@ -28,8 +28,6 @@ lazy val root = (project in file(".")).enablePlugins(
 
 enablePlugins(SystemdPlugin)
 
-debianPackageDependencies := Seq("openjdk-8-jre-headless")
-
 packageSummary := "Memsub-promotions"
 packageDescription := """Memsub-promotions tool"""
 maintainer := "Membership Dev <membership.dev@theguardian.com>"

--- a/conf/riff-raff.yaml
+++ b/conf/riff-raff.yaml
@@ -7,7 +7,7 @@ deployments:
     parameters:
       templatePath: cfn.yaml
       amiTags:
-        Recipe: bionic-membership-ARM
+        Recipe: bionic-membership-java11
         AmigoStage: PROD
       amiParameter: AmiId
       amiEncrypted: true


### PR DESCRIPTION
The department is migrating scala apps to java 11.

Steps I have taken:
1. Created a new AMI recipe in Amigo, called `bionic-membership-java11`. I did this by cloning the existing `bionic-membership-ARM` recipe and changing the java version.
2. Updated (in this PR) the riff-raff.yaml to use the new recipe, and the java flags in the build.sbt
3. Updated the teamcity build to use java 11 for the JAVA_HOME env var

It builds/deploys to CODE successfully.