### PR TITLE
Ubuntu Jammy

### DIFF
--- a/conf/riff-raff.yaml
+++ b/conf/riff-raff.yaml
@@ -7,7 +7,7 @@ deployments:
     parameters:
       templatePath: cfn.yaml
       amiTags:
-        Recipe: bionic-membership-java11
+        Recipe: jammy-membership-java11
         AmigoStage: PROD
       amiParameter: AmiId
       amiEncrypted: true

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -25,4 +25,4 @@ addSbtPlugin("com.gu" % "sbt-riffraff-artifact" % "1.1.3")
 
 addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.10.0-RC1")
 
-libraryDependencies += "org.vafer" % "jdeb" % "1.5" artifacts (Artifact("jdeb", "jar", "jar"))
+libraryDependencies += "org.vafer" % "jdeb" % "1.10" artifacts (Artifact("jdeb", "jar", "jar"))


### PR DESCRIPTION
Ubuntu Bionic is approaching end of life. This PR updates the metering api to use an AMI based on Jammy.