### PR TITLE
Ubuntu Jammy (v2)

### DIFF
--- a/cloudformation/memsub-promotions-cf.yaml
+++ b/cloudformation/memsub-promotions-cf.yaml
@@ -223,13 +223,8 @@ Resources:
               aws s3 cp s3://gu-reader-revenue-private/${Stack}/${App}/${Stage}/memsub-promotions-keys.conf /etc/gu
               chown promotions-tool /etc/gu/memsub-promotions-keys.conf
               chmod 0600 /etc/gu/memsub-promotions-keys.conf
-              wget https://s3.amazonaws.com/aws-cloudwatch/downloads/latest/awslogs-agent-setup.py
 
-              sed -i -e "s/__DATE/$(date +%F)/" -e 's/__STAGE/${Stage}/' $CONF_DIR/logger.conf
-              python awslogs-agent-setup.py -nr ${AWS::Region} -c $CONF_DIR/logger.conf
-
-              systemctl enable awslogs
-              systemctl start awslogs
+              /opt/cloudwatch-logs/configure-logs application membership ${Stage} promotions-tool /var/log/promotions-tool/promotions-tool.log
             - {}
   LoadBalancerSecurityGroup:
     Type: AWS::EC2::SecurityGroup

--- a/conf/logger.conf
+++ b/conf/logger.conf
@@ -1,8 +1,0 @@
-[general]
-state_file = /var/awslogs/agent-state
-
-[promotions-tool]
-file = /var/log/promotions-tool/promotions-tool.log
-log_group_name = MemsubPromotions-__STAGE
-log_stream_name = __DATE/__BUILD/{instance_id}/memsub-promotions.log
-datetime_format = %Y-%m-%d %H:%M-%S

--- a/conf/riff-raff.yaml
+++ b/conf/riff-raff.yaml
@@ -7,7 +7,7 @@ deployments:
     parameters:
       templatePath: cfn.yaml
       amiTags:
-        Recipe: bionic-membership-java11
+        Recipe: jammy-membership-java11
         AmigoStage: PROD
       amiParameter: AmiId
       amiEncrypted: true

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -25,4 +25,4 @@ addSbtPlugin("com.gu" % "sbt-riffraff-artifact" % "1.1.3")
 
 addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.10.0-RC1")
 
-libraryDependencies += "org.vafer" % "jdeb" % "1.5" artifacts (Artifact("jdeb", "jar", "jar"))
+libraryDependencies += "org.vafer" % "jdeb" % "1.10" artifacts (Artifact("jdeb", "jar", "jar"))


### PR DESCRIPTION
With this PR the cloudwatch log group has been renamed from:
`MemsubPromotions-<STAGE>`
to
`membership-promotions-tool-<STAGE>`

This is because it now uses the standard `configure-logs` script