### PR TITLE
salesforce lambda: load config from S3

### DIFF
--- a/cloudformation/memsub-promotions-lambdas-cf.yaml
+++ b/cloudformation/memsub-promotions-lambdas-cf.yaml
@@ -195,37 +195,6 @@ Resources:
       Runtime: nodejs12.x
       Timeout: 60
 
-  SalesforceLambdaKMSKey:
-    Type: AWS::KMS::Key
-    Properties:
-      Description: !Sub Used by the MembershipSub-Promotions Salesforce Lambda to encrypt and decrypt any environment variables
-      KeyPolicy:
-        Version: '2012-10-17'
-        Id: !Sub MembershipSub-Promotions-Salesforce-Lambda-kms-key-policy
-        Statement:
-        - Sid: Enable IAM User Permissions
-          Effect: Allow
-          Principal:
-            AWS: !Sub arn:aws:iam::${AWS::AccountId}:root
-          Action: kms:*
-          Resource: "*"
-        - Sid: Allow use of the key
-          Effect: Allow
-          Principal:
-            AWS: !GetAtt [MembershipSubPromoCodeViewETLRole, Arn]
-          Action:
-          - kms:Encrypt
-          - kms:Decrypt
-          - kms:ReEncrypt*
-          - kms:GenerateDataKey*
-          - kms:DescribeKey
-          Resource: "*"
-  SalesforceLambdaKMSKeyAlias:
-    Type: AWS::KMS::Alias
-    Properties:
-      AliasName: !Sub alias/MembershipSub-Promotions-Salesforce-Lambda-kms-key
-      TargetKeyId: !Ref 'SalesforceLambdaKMSKey'
-
   PromoCodeViewSalesforceLambdaFunctionCODE:
     Type: AWS::Lambda::Function
     Properties:
@@ -239,7 +208,6 @@ Resources:
       Role: !GetAtt [MembershipSubPromoCodeViewETLRole, Arn]
       Runtime: nodejs12.x
       Timeout: 60
-      KmsKeyArn: !GetAtt SalesforceLambdaKMSKey.Arn
 
   PromoCodeViewSalesforceLambdaFunctionPROD:
     Type: AWS::Lambda::Function
@@ -254,7 +222,6 @@ Resources:
       Role: !GetAtt [MembershipSubPromoCodeViewETLRole, Arn]
       Runtime: nodejs12.x
       Timeout: 60
-      KmsKeyArn: !GetAtt SalesforceLambdaKMSKey.Arn
 
   ScheduledBackupLambdaPROD:
     Type: AWS::Lambda::Function
@@ -269,7 +236,6 @@ Resources:
       Role: !GetAtt [MembershipSubPromotionsDataBackupLambdaRole, Arn]
       Runtime: nodejs12.x
       Timeout: 60
-      KmsKeyArn: !GetAtt SalesforceLambdaKMSKey.Arn
   BackupSchedule:
     Type: AWS::Events::Rule
     Properties:

--- a/cloudformation/memsub-promotions-lambdas-cf.yaml
+++ b/cloudformation/memsub-promotions-lambdas-cf.yaml
@@ -226,29 +226,6 @@ Resources:
       AliasName: !Sub alias/MembershipSub-Promotions-Salesforce-Lambda-kms-key
       TargetKeyId: !Ref 'SalesforceLambdaKMSKey'
 
-  PromoCodeViewSalesforceLambdaCODERole:
-    Type: AWS::IAM::Role
-    Properties:
-      AssumeRolePolicyDocument:
-        Statement:
-          - Effect: Allow
-            Principal:
-              Service:
-                - lambda.amazonaws.com
-            Action:
-              - sts:AssumeRole
-      Path: /
-      Policies:
-        - PolicyName: PromoCodeViewSalesforceLambdaCODES3Policy
-          PolicyDocument:
-            Version: '2012-10-17'
-            Statement:
-              - Effect: Allow
-                Action:
-                  - s3:GetObject
-                Resource:
-                  - arn:aws:s3:::gu-reader-revenue-private/membership/promotions-tool/CODE/*
-
   PromoCodeViewSalesforceLambdaFunctionCODE:
     Type: AWS::Lambda::Function
     Properties:

--- a/cloudformation/memsub-promotions-lambdas-cf.yaml
+++ b/cloudformation/memsub-promotions-lambdas-cf.yaml
@@ -130,6 +130,12 @@ Resources:
             - s3:PutObjectAcl
             Resource:
             - arn:aws:s3:::ophan-raw-membership-promo-code-view/*
+          - Effect: Allow
+            Action:
+            - s3:GetObject
+            Resource:
+            - arn:aws:s3:::gu-reader-revenue-private/membership/promotions-tool/*
+
   PromoCodeViewLambdaFunctionCODE:
     Type: AWS::Lambda::Function
     Properties:
@@ -220,6 +226,29 @@ Resources:
       AliasName: !Sub alias/MembershipSub-Promotions-Salesforce-Lambda-kms-key
       TargetKeyId: !Ref 'SalesforceLambdaKMSKey'
 
+  PromoCodeViewSalesforceLambdaCODERole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service:
+                - lambda.amazonaws.com
+            Action:
+              - sts:AssumeRole
+      Path: /
+      Policies:
+        - PolicyName: PromoCodeViewSalesforceLambdaCODES3Policy
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Effect: Allow
+                Action:
+                  - s3:GetObject
+                Resource:
+                  - arn:aws:s3:::gu-reader-revenue-private/membership/promotions-tool/CODE/*
+
   PromoCodeViewSalesforceLambdaFunctionCODE:
     Type: AWS::Lambda::Function
     Properties:
@@ -234,13 +263,7 @@ Resources:
       Runtime: nodejs12.x
       Timeout: 60
       KmsKeyArn: !GetAtt SalesforceLambdaKMSKey.Arn
-      Environment:
-        Variables:
-          client_id: ''
-          client_secret: ''
-          password: ''
-          salesforce_url: 'test.salesforce.com'
-          username: ''
+
   PromoCodeViewSalesforceLambdaFunctionPROD:
     Type: AWS::Lambda::Function
     Properties:
@@ -255,13 +278,7 @@ Resources:
       Runtime: nodejs12.x
       Timeout: 60
       KmsKeyArn: !GetAtt SalesforceLambdaKMSKey.Arn
-      Environment:
-        Variables:
-          client_id: ''
-          client_secret: ''
-          password: ''
-          salesforce_url: ''
-          username: ''
+
   ScheduledBackupLambdaPROD:
     Type: AWS::Lambda::Function
     Properties:

--- a/lambdas/src/MembershipSub-PromoCode-View-Dynamo-to-Salesforce.js
+++ b/lambdas/src/MembershipSub-PromoCode-View-Dynamo-to-Salesforce.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const AWS = require('aws-sdk');
-const KMS = new AWS.KMS();
+const s3 = new AWS.S3();
 
 const https = require('https');
 const querystring = require('querystring');
@@ -19,37 +19,6 @@ function generateCSVPromise(data) {
     return Promise.resolve(CSVData.join('\n'));
 }
 
-function getLoginDataFromEnvironment() {
-    const loginData = { 'grant_type': 'password' }
-    return decryptEnvironmentVariable('client_id')(loginData)
-        .then(decryptEnvironmentVariable('client_secret'))
-        .then(plaintextEnvironmentVariable('username'))
-        .then(decryptEnvironmentVariable('password'));
-}
-
-function plaintextEnvironmentVariable(fieldName) {
-    return function (collection) {
-        collection[fieldName] = process.env[fieldName];
-        return Promise.resolve(collection);
-    };
-}
-
-function decryptEnvironmentVariable(fieldName) {
-    return function (collection) {
-        const encrypted = process.env[fieldName];
-        return new Promise((fulfilled, rejected) => {
-            KMS.decrypt({CiphertextBlob: Buffer.from(encrypted, 'base64')}, (err, data) => {
-                if (err) {
-                    rejected(`Decrypt error: ${err}`);
-                } else {
-                    collection[fieldName] = data.Plaintext.toString('ascii');
-                    fulfilled(collection);
-                }
-            });
-        });
-    };
-}
-
 function makeSalesforceAPIRequest(options, requestBody, onEnd, onReqError) {
     console.log(`Making ${options.method} request to https://${options.hostname}${options.path}`);
     const req = https.request(options, (res) => {
@@ -62,7 +31,14 @@ function makeSalesforceAPIRequest(options, requestBody, onEnd, onReqError) {
     req.end();
 }
 
-function login(loginData) {
+function login(config) {
+    const loginData = {
+        grant_type: 'password',
+        client_id: config.client_id,
+        client_secret: config.client_secret,
+        username: config.username,
+        password: config.password,
+    }
     const body = querystring.stringify(loginData);
     const options = {
         hostname: process.env.salesforce_url,
@@ -242,20 +218,39 @@ function makeAPICalls(csvData) {
     };
 }
 
+function fetchConfig(stage) {
+    const Key = `membership/promotions-tool/${stage}/PromoCode-View-Dynamo-to-Salesforce-lambda.json`;
+    return s3.getObject({
+        Bucket: 'gu-reader-revenue-private',
+        Key,
+    }).promise().then(response => {
+        if (response.Body) {
+            const config = JSON.parse(response.Body.toString());
+            if (config.client_id && config.client_secret && config.password && config.salesforce_url && config.username) {
+                return config;
+            } else {
+                return Promise.reject(`Invalid config from key: ${Key}`);
+            }
+        } else {
+            return Promise.reject(`Failed to fetch config with key: ${Key}`);
+        }
+    })
+}
+
 exports.handler = (event, context, callback) => {
 
     const TOUCHPOINT_BACKEND = /PROD$/.test(context.functionName) ? 'PROD' : 'CODE';
     const TableName = `MembershipSub-PromoCode-View-${TOUCHPOINT_BACKEND}`;
 
-    docClient.scan({ TableName })
-        .promise()
-        .then(generateCSVPromise)
-        .then(csvData =>
-            getLoginDataFromEnvironment()
-                .then(login)
-                .then(makeAPICalls(csvData))
-                .then(successMessage => callback(null, `${successMessage} from table ${TableName}`))
-        )
-        .catch(callback);
-
+    fetchConfig(TOUCHPOINT_BACKEND).then(config => {
+        docClient.scan({ TableName })
+            .promise()
+            .then(generateCSVPromise)
+            .then(csvData =>
+                login(config)
+                    .then(makeAPICalls(csvData))
+                    .then(successMessage => callback(null, `${successMessage} from table ${TableName}`))
+            )
+            .catch(callback);
+    });
 };

--- a/lambdas/src/MembershipSub-PromoCode-View-Dynamo-to-Salesforce.js
+++ b/lambdas/src/MembershipSub-PromoCode-View-Dynamo-to-Salesforce.js
@@ -41,7 +41,7 @@ function login(config) {
     }
     const body = querystring.stringify(loginData);
     const options = {
-        hostname: process.env.salesforce_url,
+        hostname: config.salesforce_url,
         port: 443,
         path: '/services/oauth2/token',
         method: 'POST',


### PR DESCRIPTION
Previously we were getting salesforce credentials from environment variables, and this recently got wiped.
This PR changes it to fetch the config from S3. In a follow up we'll migrate to Secrets Manager, as this is now the standard place for salesforce config.

This PR also removes the use of KMS, which was for decrypting the environment variables.