### PR TITLE
Configure Riff Raff to deploy lambda cloudformation

### DIFF
--- a/.github/workflows/memsub-promotions-lambdas.yml
+++ b/.github/workflows/memsub-promotions-lambdas.yml
@@ -66,7 +66,7 @@ jobs:
                 type: cloud-formation
                 app: MembershipSub-Promotions-PromoCode-View
                 parameters:
-                  cloudFormationStackName: memsub-promotions-lambda
+                  cloudFormationStackName: memsub-promotions-lambdas
                   templateStagePaths:
                     PROD: memsub-promotions-lambdas-cf.yaml
                   cloudFormationStackByTags: false

--- a/.github/workflows/memsub-promotions-lambdas.yml
+++ b/.github/workflows/memsub-promotions-lambdas.yml
@@ -42,7 +42,7 @@ jobs:
           npm install -g yarn
           yarn install
           yarn compile
-          
+
           cp package.json dist
           pushd dist
           yarn dist
@@ -60,9 +60,18 @@ jobs:
             regions:
               - eu-west-1
             allowedStages:
-              - CODE
               - PROD
             deployments:
+              memsub-promotions-lambdas-cloudformation:
+                type: cloud-formation
+                app: MembershipSub-Promotions-PromoCode-View
+                parameters:
+                  cloudFormationStackName: memsub-promotions-lambda
+                  templateStagePaths:
+                    PROD: memsub-promotions-lambdas-cf.yaml
+                  cloudFormationStackByTags: false
+                  prependStackToCloudFormationStackName: false
+                  appendStageToCloudFormationStackName: false
               MembershipSub-Promotions-PromoCode-View:
                 type: aws-lambda
                 parameters:
@@ -77,3 +86,5 @@ jobs:
           contentDirectories: |
             MembershipSub-Promotions-PromoCode-View:
               - lambdas/dist/MembershipSub-Promotions-PromoCode-View.zip
+            memsub-promotions-lambdas-cloudformation:
+              - cloudformation/memsub-promotions-lambdas-cf.yaml


### PR DESCRIPTION

## What does this change?

Currently updating the Cloudformation stack has to happen manually. It'd be better for Riff Raff to deploy it.

Note: I've removed CODE from allowed stages in the RR config, since it currently fails to deploy the lambdas and there isn't a CODE Cloudformation stack.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
