### PR TITLE
Fix (sometimes) broken date picker

### DIFF
--- a/frontend/src/config/DateConfig.es6
+++ b/frontend/src/config/DateConfig.es6
@@ -1,4 +1,14 @@
 /* @ngInject */
 export default ($mdDateLocaleProvider) => {
-    $mdDateLocaleProvider.formatDate = date => date ? date.toLocaleDateString('en-GB') : ''
+    $mdDateLocaleProvider.formatDate = date => {
+        const formattedDate = date ? date.toLocaleDateString('en-GB') : '';
+        return formattedDate;
+    }
+
+    $mdDateLocaleProvider.parseDate = date => {
+        if (date) {
+            const [day, month, year] = date.split("/");
+            return new Date(year, month - 1, day);
+        }
+    }
 }

--- a/frontend/src/config/DateConfig.es6
+++ b/frontend/src/config/DateConfig.es6
@@ -1,4 +1,0 @@
-/* @ngInject */
-export default ($mdDateLocaleProvider) => {
-    $mdDateLocaleProvider.formatDate = date => date ? date.toLocaleDateString('en-GB') : ''
-}

--- a/frontend/src/config/DateConfig.es6
+++ b/frontend/src/config/DateConfig.es6
@@ -1,0 +1,4 @@
+/* @ngInject */
+export default ($mdDateLocaleProvider) => {
+    $mdDateLocaleProvider.formatDate = date => date ? date.toLocaleDateString('en-GB') : ''
+}

--- a/frontend/src/main.es6
+++ b/frontend/src/main.es6
@@ -28,6 +28,7 @@ import previewPromotion from 'directives/PreviewPromotion'
 import gridImageSelector from 'directives/GridImageSelector'
 
 //config
+import dateConfig from 'config/DateConfig'
 import urlConfig from 'config/UrlConfig'
 
 // services
@@ -87,6 +88,7 @@ module.service('promotionService', PromotionService)
       .directive('availableCountries', availableCountries)
       .directive('gridImageSelector', gridImageSelector)
       .directive('previewPromotion', previewPromotion)
+      .config(dateConfig)
       .config(urlConfig)
 ;
 

--- a/frontend/src/main.es6
+++ b/frontend/src/main.es6
@@ -28,7 +28,6 @@ import previewPromotion from 'directives/PreviewPromotion'
 import gridImageSelector from 'directives/GridImageSelector'
 
 //config
-import dateConfig from 'config/DateConfig'
 import urlConfig from 'config/UrlConfig'
 
 // services
@@ -88,7 +87,6 @@ module.service('promotionService', PromotionService)
       .directive('availableCountries', availableCountries)
       .directive('gridImageSelector', gridImageSelector)
       .directive('previewPromotion', previewPromotion)
-      .config(dateConfig)
       .config(urlConfig)
 ;
 


### PR DESCRIPTION
## What does this change?

After the Node + NPM lib upgrades in #255 we found that the date picker was sometimes breaking. After lots of debugging/trial and error we discovered that the datepicker was only broken when the day potion of the date was > 12. This lead us to believe this was a date locale problem. ~~As an experiment we tried removing the formatDate change we were making in DateConfig and this got things working. We aren't sure why! It doesn't seem to have broken anything else.~~ Out first approach _did_ break something. Dates in the input field weren't correctly formatted. Instead the right approach is to add the formatting back in and to add a parseDate function, which knows how to go from our formatted date back to a Date object.

## How to test

Open a date picker!

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
