### PR TITLE
Fix country checkbox alignment

### DIFF
--- a/frontend/src/templates/AvailableCountries.html
+++ b/frontend/src/templates/AvailableCountries.html
@@ -1,6 +1,6 @@
 <div layout="column" flex layout-align="top left">
     <h5>Availability</h5>
-    <div>
+    <div layout="row">
         <md-checkbox ng-model="selectedCountryGroups[group.id]" aria-label="{{group.name}}" ng-repeat="group in countryGroups" ng-change="ctrl.applyCountryGroups(selectedCountryGroups)">
             {{group.name}}
         </md-checkbox>


### PR DESCRIPTION
## What does this change?

Fixes an alignment issue with the country checkboxes, reported by Craig.

### Before:

![Screenshot 2023-07-19 at 17 12 46](https://github.com/guardian/memsub-promotions/assets/379839/b615f9b0-eb36-4b13-81be-e796af9083bc)

### After:

![Screenshot 2023-07-19 at 17 12 08](https://github.com/guardian/memsub-promotions/assets/379839/4daee3ae-1251-452e-b7cc-4802abd51f43)


<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
