### PR TITLE
Better validation for readSupporterPlusV2ChargeList

### DIFF
--- a/app/com/gu/memsub/subsv2/Plan.scala
+++ b/app/com/gu/memsub/subsv2/Plan.scala
@@ -53,16 +53,7 @@ object EndDateCondition {
   implicit val reads: Reads[EndDateCondition] = ZuoraEnum.getReads(values, "invalid end date condition value")
 }
 
-sealed trait ZBillingPeriod extends ZuoraEnum {
-  def toBillingPeriod: BillingPeriod = this match {
-    case ZYear => Year
-    case ZTwoYears => TwoYears
-    case ZThreeYears => ThreeYears
-    case ZMonth => Month
-    case ZQuarter => Quarter
-    case  _ => throw new IllegalArgumentException("Zuora billing period not supported")
-  }
-}
+sealed trait ZBillingPeriod extends ZuoraEnum
 
 case object ZYear extends ZBillingPeriod {
   override val id = "Annual"

--- a/app/com/gu/memsub/subsv2/reads/ChargeListReads.scala
+++ b/app/com/gu/memsub/subsv2/reads/ChargeListReads.scala
@@ -183,11 +183,17 @@ object ChargeListReads {
 
   implicit def readSupporterPlusV2ChargeList: ChargeListReads[SupporterPlusCharges] = new ChargeListReads[SupporterPlusCharges] {
 
+    def validateBillingPeriod(zBillingPeriod: ZBillingPeriod): ValidationNel[String, BillingPeriod] = zBillingPeriod match {
+      case ZMonth => Validation.success[NonEmptyList[String], BillingPeriod](Month)
+      case ZYear => Validation.success[NonEmptyList[String], BillingPeriod](Year)
+      case _ => Validation.failureNel(s"Supporter plus V2 must have a Monthly or Annual billing period, not $zBillingPeriod")
+    }
+
     def getBillingPeriod(charges: List[ZuoraCharge]): ValidationNel[String, BillingPeriod] = {
       val billingPeriods = charges.flatMap(_.billingPeriod).distinct
       billingPeriods match {
         case Nil => Validation.failureNel("No billing period found")
-        case b :: Nil => Validation.success[NonEmptyList[String], BillingPeriod](b.toBillingPeriod)
+        case b :: Nil => validateBillingPeriod(b)
         case _ => Validation.failureNel("Too many billing periods found")
       }
     }


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
The `readSupporterPlusV2ChargeList` ChargeListReads object was quite loose in the type of charges it would match which meant that some subscriptions could be mistakenly identified as supporter plus subs.

This PR tightens the deserialisation up so that it only matches charges with billing periods which are valid for supporter plus subscriptions.

original change in https://github.com/guardian/members-data-api/pull/1033