### PR TITLE
Add supporter plus

### DIFF
--- a/app/com/gu/config/SupporterPlusRatePlanIds.scala
+++ b/app/com/gu/config/SupporterPlusRatePlanIds.scala
@@ -1,0 +1,16 @@
+package com.gu.config
+
+import com.gu.memsub.Subscription.ProductRatePlanId
+
+case class SupporterPlusRatePlanIds(yearly: ProductRatePlanId, monthly: ProductRatePlanId)
+    extends ProductFamilyRatePlanIds {
+  override val productRatePlanIds: Set[ProductRatePlanId] = Set(yearly, monthly)
+}
+
+object SupporterPlusRatePlanIds {
+  def fromConfig(config: com.typesafe.config.Config): SupporterPlusRatePlanIds =
+    SupporterPlusRatePlanIds(
+      ProductRatePlanId(config.getString("yearly")),
+      ProductRatePlanId(config.getString("monthly"))
+    )
+}

--- a/app/com/gu/memsub/promo/Formatters.scala
+++ b/app/com/gu/memsub/promo/Formatters.scala
@@ -9,9 +9,8 @@ import com.gu.memsub.promo.Promotion.AnyPromotion
 import io.lemonlabs.uri.Uri
 import org.joda.time.{DateTime, Days}
 import play.api.libs.functional.syntax._
-
 import play.api.libs.json._
-import com.gu.memsub.promo.CampaignGroup.{DigitalPack, GuardianWeekly, Newspaper}
+import com.gu.memsub.promo.CampaignGroup.{DigitalPack, GuardianWeekly, Newspaper, SupporterPlus}
 
 object Formatters {
 
@@ -119,6 +118,7 @@ object Formatters {
       new Reads[LandingPage] {
         // Supports the legacy serialisations of productFamily key as the identifier of a LandingPage type
         override def reads(json: JsValue): JsResult[LandingPage] = (json \ "productFamily").toOption orElse (json \ "type").toOption match {
+          case Some(JsString(SupporterPlus.id))  => Json.reads[SupporterPlusLandingPage].reads(json)
           case Some(JsString(DigitalPack.id))  => Json.reads[DigitalPackLandingPage].reads(json)
           case Some(JsString(Newspaper.id))  => Json.reads[NewspaperLandingPage].reads(json)
           case Some(JsString(GuardianWeekly.id)) => Json.reads[WeeklyLandingPage].reads(json)
@@ -128,6 +128,7 @@ object Formatters {
       new OWrites[LandingPage] {
         def writes(in: LandingPage): JsObject = {
           in match {
+            case slp: SupporterPlusLandingPage => Json.writes[SupporterPlusLandingPage].writes(slp) ++ Json.obj("type" -> SupporterPlus.id)
             case dlp: DigitalPackLandingPage => Json.writes[DigitalPackLandingPage].writes(dlp) ++ Json.obj("type" -> DigitalPack.id)
             case nlp: NewspaperLandingPage => Json.writes[NewspaperLandingPage].writes(nlp) ++ Json.obj("type" -> Newspaper.id)
             case wlp: WeeklyLandingPage => Json.writes[WeeklyLandingPage].writes(wlp) ++ Json.obj("type" -> GuardianWeekly.id)
@@ -136,6 +137,7 @@ object Formatters {
       }
     )
 
+    implicit val supporterPlusLandingPageFormat = Json.format[SupporterPlusLandingPage]
     implicit val digitalpackLandingPageFormat = Json.format[DigitalPackLandingPage]
     implicit val newspaperLandingPageFormat = Json.format[NewspaperLandingPage]
 

--- a/app/com/gu/memsub/promo/Promotion.scala
+++ b/app/com/gu/memsub/promo/Promotion.scala
@@ -31,6 +31,9 @@ sealed trait CampaignGroup {
 }
 object CampaignGroup {
 
+  case object SupporterPlus extends CampaignGroup {
+    override val id = "supporterplus"
+  }
   case object DigitalPack extends CampaignGroup {
     override val id = "digitalpack"
   }
@@ -43,6 +46,7 @@ object CampaignGroup {
 
   def fromId(id: String): Option[CampaignGroup] = id match {
     case DigitalPack.id => Some(DigitalPack)
+    case SupporterPlus.id => Some(SupporterPlus)
     case Newspaper.id => Some(Newspaper)
     case GuardianWeekly.id => Some(GuardianWeekly)
     case _ => None
@@ -140,6 +144,15 @@ case object Bottom extends HeroImageAlignment
 case object Centre extends HeroImageAlignment
 case class HeroImage(image: ResponsiveImageGroup, alignment: HeroImageAlignment)
 
+case class MembershipLandingPage(
+  title: Option[String],
+  subtitle: Option[String],
+  description: Option[String],
+  roundelHtml: Option[String],
+  heroImage: Option[HeroImage],
+  image: Option[ResponsiveImageGroup]
+) extends LandingPage
+
 case class DigitalPackLandingPage(
   title: Option[String],
   description: Option[String],
@@ -210,6 +223,7 @@ object CovariantIdObject {
 object Promotion {
 
   type AnyPromotion = Promotion[PromotionType[PromoContext], Option, LandingPage]
+  type PromoWithMembershipLandingPage = Promotion[PromotionType[PromoContext], CovariantId, MembershipLandingPage]
   type PromoWithDigitalPackLandingPage = Promotion[PromotionType[PromoContext], CovariantId, DigitalPackLandingPage]
   type PromoWithNewspaperLandingPage = Promotion[PromotionType[PromoContext], CovariantId, NewspaperLandingPage]
   type PromoWithWeeklyLandingPage = Promotion[PromotionType[PromoContext], CovariantId, WeeklyLandingPage]
@@ -259,6 +273,7 @@ object Promotion {
     def asDigitalPack: PromoOpt[DigitalPackLandingPage] = in.landingPage.collect { case f: DigitalPackLandingPage => in.copy[A, CovariantId, DigitalPackLandingPage](landingPage = (f)) }
     def asNewspaper: PromoOpt[NewspaperLandingPage] = in.landingPage.collect { case f: NewspaperLandingPage => in.copy[A, CovariantId, NewspaperLandingPage](landingPage = (f)) }
     def asWeekly: PromoOpt[WeeklyLandingPage] = in.landingPage.collect { case f: WeeklyLandingPage => in.copy[A, CovariantId, WeeklyLandingPage](landingPage = (f)) }
+    def asMembership: PromoOpt[MembershipLandingPage] = in.landingPage.collect { case f: MembershipLandingPage => in.copy[A, CovariantId, MembershipLandingPage](landingPage = (f)) }
   }
 
   def asAnyPromotion[T <: PromotionType[PromoContext]](in: Promotion[T, CovariantId, LandingPage]): AnyPromotion =

--- a/app/com/gu/memsub/promo/Promotion.scala
+++ b/app/com/gu/memsub/promo/Promotion.scala
@@ -144,7 +144,7 @@ case object Bottom extends HeroImageAlignment
 case object Centre extends HeroImageAlignment
 case class HeroImage(image: ResponsiveImageGroup, alignment: HeroImageAlignment)
 
-case class MembershipLandingPage(
+case class SupporterPlusLandingPage(
   title: Option[String],
   subtitle: Option[String],
   description: Option[String],
@@ -223,7 +223,7 @@ object CovariantIdObject {
 object Promotion {
 
   type AnyPromotion = Promotion[PromotionType[PromoContext], Option, LandingPage]
-  type PromoWithMembershipLandingPage = Promotion[PromotionType[PromoContext], CovariantId, MembershipLandingPage]
+  type PromoWithSupporterPlusLandingPage = Promotion[PromotionType[PromoContext], CovariantId, SupporterPlusLandingPage]
   type PromoWithDigitalPackLandingPage = Promotion[PromotionType[PromoContext], CovariantId, DigitalPackLandingPage]
   type PromoWithNewspaperLandingPage = Promotion[PromotionType[PromoContext], CovariantId, NewspaperLandingPage]
   type PromoWithWeeklyLandingPage = Promotion[PromotionType[PromoContext], CovariantId, WeeklyLandingPage]
@@ -273,7 +273,7 @@ object Promotion {
     def asDigitalPack: PromoOpt[DigitalPackLandingPage] = in.landingPage.collect { case f: DigitalPackLandingPage => in.copy[A, CovariantId, DigitalPackLandingPage](landingPage = (f)) }
     def asNewspaper: PromoOpt[NewspaperLandingPage] = in.landingPage.collect { case f: NewspaperLandingPage => in.copy[A, CovariantId, NewspaperLandingPage](landingPage = (f)) }
     def asWeekly: PromoOpt[WeeklyLandingPage] = in.landingPage.collect { case f: WeeklyLandingPage => in.copy[A, CovariantId, WeeklyLandingPage](landingPage = (f)) }
-    def asMembership: PromoOpt[MembershipLandingPage] = in.landingPage.collect { case f: MembershipLandingPage => in.copy[A, CovariantId, MembershipLandingPage](landingPage = (f)) }
+    def asSupporterPlus: PromoOpt[SupporterPlusLandingPage] = in.landingPage.collect { case f: SupporterPlusLandingPage => in.copy[A, CovariantId, SupporterPlusLandingPage](landingPage = (f)) }
   }
 
   def asAnyPromotion[T <: PromotionType[PromoContext]](in: Promotion[T, CovariantId, LandingPage]): AnyPromotion =

--- a/app/com/gu/memsub/promo/Promotion.scala
+++ b/app/com/gu/memsub/promo/Promotion.scala
@@ -32,7 +32,7 @@ sealed trait CampaignGroup {
 object CampaignGroup {
 
   case object SupporterPlus extends CampaignGroup {
-    override val id = "supporterplus"
+    override val id = "supporterPlus"
   }
   case object DigitalPack extends CampaignGroup {
     override val id = "digitalpack"

--- a/app/controllers/RatePlanController.scala
+++ b/app/controllers/RatePlanController.scala
@@ -1,12 +1,12 @@
 package controllers
 
 import actions.GoogleAuthAction.GoogleAuthenticatedAction
-import com.gu.config.DigitalPackRatePlanIds
+import com.gu.config.{DigitalPackRatePlanIds, SupporterPlusRatePlanIds}
 import com.gu.i18n.Currency
 import com.gu.i18n.Currency.{AUD, CAD, EUR, GBP, USD}
 import com.gu.memsub.Price
 import com.gu.memsub.Subscription.ProductRatePlanId
-import com.gu.memsub.promo.CampaignGroup.{DigitalPack, GuardianWeekly, Newspaper}
+import com.gu.memsub.promo.CampaignGroup.{DigitalPack, GuardianWeekly, Newspaper, SupporterPlus}
 import com.gu.memsub.subsv2.services.CatalogService
 import com.typesafe.scalalogging.LazyLogging
 import conf.{PaperProducts, WeeklyPlans}
@@ -18,24 +18,33 @@ import scala.concurrent.Future
 
 case class RatePlan(ratePlanId: ProductRatePlanId, ratePlanName: String)
 
-case class EnhancedRatePlan(ratePlanId: ProductRatePlanId, ratePlanName: String, price: Option[String], priceSummary: Option[Iterable[Price]], description: Option[String],period:Option[Int])
+case class EnhancedRatePlan(
+    ratePlanId: ProductRatePlanId,
+    ratePlanName: String,
+    price: Option[String],
+    priceSummary: Option[Iterable[Price]],
+    description: Option[String],
+    period: Option[Int],
+)
 
 class RatePlanController(
     googleAuthAction: GoogleAuthenticatedAction,
     paperPlans: PaperProducts,
     digipackIds: DigitalPackRatePlanIds,
+    supporterPlusIds: SupporterPlusRatePlanIds,
     weeklyPlans: WeeklyPlans,
-    catalogService: CatalogService[Future]
-  ) {
+    catalogService: CatalogService[Future],
+) {
 
-  def sortCurrency = (price: Price) => price.currency match {
-    case GBP => 0
-    case USD => 1
-    case AUD => 2
-    case EUR => 3
-    case CAD => 4
-    case _ => 5
-  }
+  def sortCurrency = (price: Price) =>
+    price.currency match {
+      case GBP => 0
+      case USD => 1
+      case AUD => 2
+      case EUR => 3
+      case CAD => 4
+      case _ => 5
+    }
 
   def enhance(ratePlan: RatePlan): EnhancedRatePlan = {
     val plan = find(ratePlan.ratePlanId)
@@ -45,10 +54,9 @@ class RatePlanController(
       plan.map(_.charges.gbpPrice.prettyAmount),
       plan.map(_.charges.price.prices.toList.sortBy(sortCurrency)),
       plan.map(_.description),
-      plan.map(_.charges.billingPeriod.monthsInPeriod)
+      plan.map(_.charges.billingPeriod.monthsInPeriod),
     )
   }
-
 
   lazy val catalog = catalogService.unsafeCatalog
 
@@ -58,6 +66,10 @@ class RatePlanController(
 
   def all = googleAuthAction {
     Ok(Json.obj(
+      SupporterPlus.id -> Json.toJson(Seq(
+          RatePlan(supporterPlusIds.yearly, "Annual"),
+          RatePlan(supporterPlusIds.monthly, "Monthly"),
+      ).map(enhance)),
       DigitalPack.id -> Json.toJson(Seq(
         RatePlan(digipackIds.digitalPackMonthly, "Digital Pack monthly"),
         RatePlan(digipackIds.digitalPackQuaterly, "Digital Pack quarterly"),
@@ -122,9 +134,11 @@ class RatePlanController(
 }
 
 object RatePlanController {
-  implicit val prpidWrite: Writes[ProductRatePlanId] = (productRatePlanId: ProductRatePlanId) => JsString(productRatePlanId.get)
+  implicit val prpidWrite: Writes[ProductRatePlanId] = (productRatePlanId: ProductRatePlanId) =>
+    JsString(productRatePlanId.get)
   implicit val ratePlanWrite: OWrites[RatePlan] = Json.writes[RatePlan]
-  implicit val priceWrite: Writes[Price] = (price: Price) => Json.obj(("currency", Json.toJson(price.currency)), ("amount", JsString(price.amount.toString)))
+  implicit val priceWrite: Writes[Price] = (price: Price) =>
+    Json.obj(("currency", Json.toJson(price.currency)), ("amount", JsString(price.amount.toString)))
   implicit val currencyWrite: Writes[Currency] = (currency: Currency) => JsString(currency.iso)
   implicit val eratePlanWrite: OWrites[EnhancedRatePlan] = Json.writes[EnhancedRatePlan]
 }

--- a/app/wiring/AppComponents.scala
+++ b/app/wiring/AppComponents.scala
@@ -1,5 +1,5 @@
 package wiring
-import com.gu.config.DigitalPackRatePlanIds
+import com.gu.config.{DigitalPackRatePlanIds, SupporterPlusRatePlanIds}
 import com.gu.googleauth.AuthAction
 import com.gu.memsub.auth.common.MemSub.Google.googleAuthConfigFor
 import com.gu.memsub.promo.{Campaign, DynamoTables}
@@ -38,6 +38,7 @@ class AppComponents(context: Context) extends BuiltInComponentsFromContext(conte
   lazy val catalog = CatalogService.fromConfig(config,stage.name)
 
   lazy val digipackRatePlanIds = DigitalPackRatePlanIds.fromConfig(config.getConfig(AppComponents.ratePlanPath(stage) + ".digitalpack"))
+  lazy val supporterPlusRatePlanIds = SupporterPlusRatePlanIds.fromConfig(config.getConfig(AppComponents.ratePlanPath(stage) + ".supporterPlus"))
   lazy val weeklyRatePlanIds = WeeklyPlans.fromConfig(config, stage)
 
   private val googleAuthConfig = googleAuthConfigFor(config, httpConfiguration)

--- a/frontend/src/templates/EnvironmentMenu.html
+++ b/frontend/src/templates/EnvironmentMenu.html
@@ -4,6 +4,12 @@
     </md-button>
     <md-menu-content width="4" class="md-menu-content">
         <md-menu-item>
+            <md-button ng-click="ctrl.setCampaignGroup('supporterplus')">
+                <md-icon md-font-set="material-icons" md-menu-align-target>people</md-icon>
+                Supporter Plus
+            </md-button>
+        </md-menu-item>
+        <md-menu-item>
             <md-button ng-click="ctrl.setCampaignGroup('digitalpack')">
                 <md-icon md-font-set="material-icons" md-menu-align-target>tablet_mac</md-icon>
                 Digital Pack

--- a/frontend/src/templates/EnvironmentMenu.html
+++ b/frontend/src/templates/EnvironmentMenu.html
@@ -4,7 +4,7 @@
     </md-button>
     <md-menu-content width="4" class="md-menu-content">
         <md-menu-item>
-            <md-button ng-click="ctrl.setCampaignGroup('supporterplus')">
+            <md-button ng-click="ctrl.setCampaignGroup('supporterPlus')">
                 <md-icon md-font-set="material-icons" md-menu-align-target>people</md-icon>
                 Supporter Plus
             </md-button>


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
We want to be able to create discounts for the supporter plus product, this PR adds in the necessary rate plans and makes supporter plus available as a product from the burger menu.