### PR TITLE
Add the correct product rate plan ids for supporter plus

### DIFF
--- a/conf/touchpoint.PROD.conf
+++ b/conf/touchpoint.PROD.conf
@@ -88,8 +88,8 @@ touchpoint.backend.environments {
                     yearly="2c92a0fb4edd70c8014edeaa4e972204"
                 }
                 supporterPlus={
-                    monthly="8a12865b8219d9b401822106192b64dc"
-                    yearly="8a12865b8219d9b40182210618a464ba"
+                    monthly="8a128ed885fc6ded018602296ace3eb8"
+                    yearly="8a128ed885fc6ded01860228f77e3d5a"
                 }
             }
             invoiceTemplateIds {


### PR DESCRIPTION


<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
The supporter plus product rate plan ids in config were for the old V1 rate plans, this PR updates them to the V2 versions