### PR TITLE
Fix S3 call

### DIFF
--- a/app/com/gu/memsub/subsv2/services/CatalogService.scala
+++ b/app/com/gu/memsub/subsv2/services/CatalogService.scala
@@ -22,7 +22,7 @@ import scalaz.syntax.apply.ToApplyOps
 
 object FetchCatalog {
   def fromS3[M[_] : Monad](zuoraEnvironment: String, s3Client: AmazonS3 = AwsS3.client): M[String \/ JsValue] = {
-    val catalogRequest = new GetObjectRequest(s"gu-zuora-catalog/PROD/Zuora-${zuoraEnvironment}", "catalog.json")
+    val catalogRequest = new GetObjectRequest("gu-zuora-catalog", s"PROD/Zuora-$zuoraEnvironment/catalog.json")
     AwsS3.fetchJson(s3Client, catalogRequest).point[M]
   }
 


### PR DESCRIPTION
A [previous PR](https://github.com/guardian/memsub-promotions/pull/276) bumped the AWS dependencies.
We're now getting errors talking to S3 in the logs:
`Failed to load JSON due to com.amazonaws.services.s3.model.AmazonS3Exception: The request signature we calculated does not match the signature you provided. Check your key and signing method. If you start to see this issue after you upgrade the SDK to 1.12.460 or later, it could be because the bucket provided contains '/'.`

My testing in CODE didn't trigger this error, I think because the example promo I used didn't require this data.

The S3 SDK has changed and the parameters to `GetObjectRequest` now need to be different.