### PR TITLE
fix: use SupporterPlusV2 Zuora catalogue plans

### DIFF
--- a/app/com/gu/memsub/subsv2/Plan.scala
+++ b/app/com/gu/memsub/subsv2/Plan.scala
@@ -195,13 +195,15 @@ object FrontendId {
   case object OneYear extends FrontendId { val name = "OneYear" }
   case object ThreeMonths extends FrontendId { val name = "ThreeMonths" }
   case object Monthly extends FrontendId { val name = "Monthly" }
+  case object MonthlyV2 extends FrontendId { val name = "MonthlyV2" }
   case object Quarterly extends FrontendId { val name = "Quarterly" }
   case object Yearly extends FrontendId { val name = "Yearly" }
+  case object YearlyV2 extends FrontendId { val name = "YearlyV2" }
   case object Introductory extends FrontendId { val name = "Introductory" }
   case object Free extends FrontendId { val name = "Free" }
   case object SixWeeks extends FrontendId { val name = "SixWeeks" }
 
-  val all = List(OneYear, ThreeMonths, Monthly, Quarterly, Yearly, Introductory, Free, SixWeeks)
+  val all = List(OneYear, ThreeMonths, Monthly, MonthlyV2, Quarterly, Yearly, YearlyV2, Introductory, Free, SixWeeks)
 
   def get(jsonString: String): Option[FrontendId] =
     all.find(_.name == jsonString)

--- a/app/com/gu/memsub/subsv2/services/CatalogService.scala
+++ b/app/com/gu/memsub/subsv2/services/CatalogService.scala
@@ -75,8 +75,8 @@ class CatalogService[M[_] : Monad](productIds: ProductIds, fetchCatalog: M[Strin
         one[Digipack[Year.type]](plans, "Digipack year", FrontendId.Yearly)
       ) (DigipackPlans)
     supporterPlus <- (
-      one[SupporterPlus[Month.type]](plans, "Supporter Plus month", FrontendId.Monthly) |@|
-        one[SupporterPlus[Year.type]](plans, "Supporter Plus year", FrontendId.Yearly)
+      one[SupporterPlus[Month.type]](plans, "Supporter Plus month", FrontendId.MonthlyV2) |@|
+        one[SupporterPlus[Year.type]](plans, "Supporter Plus year", FrontendId.YearlyV2)
       ) (SupporterPlusPlans)
     contributor <- one[Contributor](plans, "Contributor month", FrontendId.Monthly)
     voucher <- many[Voucher](plans, "Paper voucher")


### PR DESCRIPTION
## What does this change?

Follow up from https://github.com/guardian/memsub-promotions/pull/278

Uses the V2 Supporter Plus plans from Zuora.

## How to test

This is now working locally.
<img width="1038" alt="Screenshot 2024-02-07 at 15 51 57" src="https://github.com/guardian/memsub-promotions/assets/31692/c02f40ed-2bd2-4265-8e3f-16efa2597518">

<img width="631" alt="Screenshot 2024-02-07 at 16 02 30" src="https://github.com/guardian/memsub-promotions/assets/31692/acf8217b-3c92-41fe-af16-beb3338e7037">

Thanks 🙇 be to @johnduffell for helping me work out how the parsing of the Zuora catalogue works here.
