### PR TITLE
Revert "fix: use SupporterPlusV2 Zuora catalogue plans"

### DIFF
--- a/app/com/gu/memsub/subsv2/Plan.scala
+++ b/app/com/gu/memsub/subsv2/Plan.scala
@@ -195,15 +195,13 @@ object FrontendId {
   case object OneYear extends FrontendId { val name = "OneYear" }
   case object ThreeMonths extends FrontendId { val name = "ThreeMonths" }
   case object Monthly extends FrontendId { val name = "Monthly" }
-  case object MonthlyV2 extends FrontendId { val name = "MonthlyV2" }
   case object Quarterly extends FrontendId { val name = "Quarterly" }
   case object Yearly extends FrontendId { val name = "Yearly" }
-  case object YearlyV2 extends FrontendId { val name = "YearlyV2" }
   case object Introductory extends FrontendId { val name = "Introductory" }
   case object Free extends FrontendId { val name = "Free" }
   case object SixWeeks extends FrontendId { val name = "SixWeeks" }
 
-  val all = List(OneYear, ThreeMonths, Monthly, MonthlyV2, Quarterly, Yearly, YearlyV2, Introductory, Free, SixWeeks)
+  val all = List(OneYear, ThreeMonths, Monthly, Quarterly, Yearly, Introductory, Free, SixWeeks)
 
   def get(jsonString: String): Option[FrontendId] =
     all.find(_.name == jsonString)

--- a/app/com/gu/memsub/subsv2/services/CatalogService.scala
+++ b/app/com/gu/memsub/subsv2/services/CatalogService.scala
@@ -75,8 +75,8 @@ class CatalogService[M[_] : Monad](productIds: ProductIds, fetchCatalog: M[Strin
         one[Digipack[Year.type]](plans, "Digipack year", FrontendId.Yearly)
       ) (DigipackPlans)
     supporterPlus <- (
-      one[SupporterPlus[Month.type]](plans, "Supporter Plus month", FrontendId.MonthlyV2) |@|
-        one[SupporterPlus[Year.type]](plans, "Supporter Plus year", FrontendId.YearlyV2)
+      one[SupporterPlus[Month.type]](plans, "Supporter Plus month", FrontendId.Monthly) |@|
+        one[SupporterPlus[Year.type]](plans, "Supporter Plus year", FrontendId.Yearly)
       ) (SupporterPlusPlans)
     contributor <- one[Contributor](plans, "Contributor month", FrontendId.Monthly)
     voucher <- many[Voucher](plans, "Paper voucher")


### PR DESCRIPTION
Reverts guardian/memsub-promotions#279

I completely forgot - this worked on `PROD`. Now it doesn't. 

The `FrontendId` in Zuora for `PROD` is `Yearly | Monthly`. In `CODE` it's `YearlyV2 | MonthlyV2`.

My suggestion is that we revert this change, and change `CODE` Zuora source data to reflect `PROD`.

An alternative would be to change the `FrontendId` in `PROD` to the `V2` version, but I am unsure of the downstream knockon effects.  