### PR TITLE
Use modern TLS protocols and ciphers

### DIFF
--- a/nginx/promotions.conf
+++ b/nginx/promotions.conf
@@ -16,9 +16,9 @@ server {
 
     ssl_session_timeout 5m;
 
-    ssl_protocols TLSv1;
-    ssl_ciphers HIGH:!aNULL:!MD5;
     ssl_prefer_server_ciphers on;
+    ssl_protocols TLSv1.2 TLSv1.3;
+    ssl_ciphers HIGH:!aNULL:!MD5;
 
     # Proxy the Websocket connection to the Webpack server - see https://stackoverflow.com/a/40549432/438886
     location /sockjs-node/ {


### PR DESCRIPTION
## What does this change?

Uses `TLSv1.2` and `TLSv1.3` for local development. We were getting a `ERR_SSL_VERSION_OR_CIPHER_MISMATCH` error locally and this fixes that.

We have seen strange behaviour where this config was affecting the `support.gulocal.com`'s config. We will need to dig deeper into that.