### PR TITLE
Upgrade to Play 3

### DIFF
--- a/app/com/gu/memsub/auth/common/MemSub.scala
+++ b/app/com/gu/memsub/auth/common/MemSub.scala
@@ -4,7 +4,7 @@ import com.amazonaws.auth.profile.ProfileCredentialsProvider
 import com.amazonaws.auth.{AWSCredentialsProviderChain, InstanceProfileCredentialsProvider}
 import com.amazonaws.services.s3.model.S3ObjectId
 import com.google.auth.oauth2.ServiceAccountCredentials
-import com.gu.googleauth.{AntiForgeryChecker, GoogleAuthConfig, GoogleGroupChecker, GoogleServiceAccount}
+import com.gu.googleauth.{AntiForgeryChecker, GoogleAuthConfig, GoogleGroupChecker}
 import com.typesafe.config.Config
 import play.api.http.HttpConfiguration
 

--- a/app/com/gu/memsub/images/ResponsiveImage.scala
+++ b/app/com/gu/memsub/images/ResponsiveImage.scala
@@ -1,15 +1,6 @@
 package com.gu.memsub.images
 
 import io.lemonlabs.uri.Uri
-import io.lemonlabs.uri.dsl._
-
-object ResponsiveImageGenerator {
-  def apply(id: String, sizes: Seq[Int], extension: String = "jpg"): Seq[ResponsiveImage] = {
-    sizes.map { size =>
-      ResponsiveImage(id.split("/").fold("https://media.guim.co.uk")({case (a, b) => a / b}) / s"$size.$extension", size)
-    }
-  }
-}
 
 case class ResponsiveImage(path: Uri, width: Int)
 
@@ -18,20 +9,4 @@ case class ResponsiveImageGroup(
  altText: Option[String] = None,
  metadata: Option[Grid.Metadata] = None,
  availableImages: Seq[ResponsiveImage]
-) {
-
-  private val sortedImages = availableImages.sortBy(_.width)
-
-  // We expect to have at least one availableImage. In the rare case we don't,
-  // set the path to about:blank, which is still a valid URL whose resource is an empty string.
-  // http://www.w3.org/TR/2011/WD-html5-20110525/fetching-resources.html#about:blank
-  val smallestImage: Uri = sortedImages.headOption.map(_.path).getOrElse("about:blank")
-  val defaultImage: Uri = sortedImages.find(_.width > 300).map(_.path).getOrElse(smallestImage)
-
-  val srcset = sortedImages.map { img =>
-    img.path.toString + " " + img.width.toString + "w"
-  }.mkString(", ")
-
-  val metadataAltText = metadata.fold(altText)(_.description)
-
-}
+)

--- a/build.sbt
+++ b/build.sbt
@@ -69,7 +69,7 @@ libraryDependencies ++= Seq(
   "org.scalaz" %% "scalaz-core" % "7.3.7",
   "com.github.nscala-time" %% "nscala-time" % "2.32.0",
   "com.gu" %% "support-internationalisation" % "0.16",
-  "io.lemonlabs" %% "scala-uri" % "2.2.0",
+  "io.lemonlabs" %% "scala-uri" % "4.0.3",
   "com.squareup.okhttp3" % "okhttp" % "4.10.0",
   "com.typesafe.play" %% "play-json-joda" % "2.10.4",
   "org.scalatestplus.play" %% "scalatestplus-play" % "7.0.1" % Test

--- a/build.sbt
+++ b/build.sbt
@@ -57,7 +57,7 @@ libraryDependencies ++= Seq(
   jdbc,
   ehcache,
   ws,
-  "com.gu.play-googleauth" %% "play-v28" % "2.2.6",
+  "com.gu.play-googleauth" %% "play-v30" % "4.0.0",
   "com.softwaremill.macwire" %% "macros" % "2.5.0" % "provided",
   "com.softwaremill.macwire" %% "util" % "2.5.0",
   "com.softwaremill.macwire" %% "proxy" % "2.5.0",
@@ -71,13 +71,8 @@ libraryDependencies ++= Seq(
   "com.gu" %% "support-internationalisation" % "0.16",
   "io.lemonlabs" %% "scala-uri" % "2.2.0",
   "com.squareup.okhttp3" % "okhttp" % "4.10.0",
-  "com.typesafe.play" %% "play-json-joda" % "2.9.4",
-  "org.scalatestplus.play" %% "scalatestplus-play" % "5.1.0" % Test
-)
-
-dependencyOverrides ++= Seq(
-  // Fixes: https://security.snyk.io/vuln/SNYK-JAVA-CHQOSLOGBACK-6094942
-  "ch.qos.logback" % "logback-classic" % "1.2.13"
+  "com.typesafe.play" %% "play-json-joda" % "2.10.4",
+  "org.scalatestplus.play" %% "scalatestplus-play" % "7.0.1" % Test
 )
 
 resolvers ++= Seq(

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.6.1
+sbt.version=1.9.9

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,5 @@
 // The Play plugin
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.8.16")
+addSbtPlugin("org.playframework" % "sbt-plugin" % "3.0.2")
 
 // web plugins
 
@@ -19,7 +19,7 @@ addSbtPlugin("org.irundaia.sbt" % "sbt-sassify" % "1.4.12")
 
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.9.0")
 
-addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.3.4")
+addSbtPlugin("com.github.sbt" % "sbt-native-packager" % "1.9.16")
 
 addSbtPlugin("com.gu" % "sbt-riffraff-artifact" % "1.1.18")
 


### PR DESCRIPTION
We are now getting snyk warnings for Play 2's Akka dependency.
Play 3 [replaces Akka with Pekko](https://www.playframework.com/documentation/3.0.x/Migration30#Migration-from-Akka-to-Pekko), which resolves this.

Tested in CODE