### PR TITLE
Revert upgrade to angular-ui-router

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -32,7 +32,7 @@
     "angular-mocks": "^1.5.11",
     "angular-route": "^1.5.11",
     "angular-sanitize": "1.8.3",
-    "angular-ui-router": "^1.0.30",
+    "angular-ui-router": "^0.4.3",
     "angular-uuid": "^0.0.4",
     "babel-loader": "^9.1.3",
     "babel-plugin-angularjs-annotate": "^0.10.0",

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -1221,11 +1221,6 @@
   dependencies:
     "@types/node" "*"
 
-"@uirouter/core@6.0.8":
-  version "6.0.8"
-  resolved "https://registry.yarnpkg.com/@uirouter/core/-/core-6.0.8.tgz#a1e919a4743be729751aafc4ce353d0dc0ffd26c"
-  integrity sha512-Gc/BAW47i4L54p8dqYCJJZuv2s3tqlXQ0fvl6Zp2xrblELPVfxmjnc0eurx3XwfQdaqm3T6uls6tQKkof/4QMw==
-
 "@webassemblyjs/ast@1.12.1", "@webassemblyjs/ast@^1.12.1":
   version "1.12.1"
   resolved "https://registry.yarnpkg.com/@webassemblyjs/ast/-/ast-1.12.1.tgz#bb16a0e8b1914f979f45864c23819cc3e3f0d4bb"
@@ -1479,19 +1474,19 @@ angular-sanitize@1.8.3:
   resolved "https://registry.yarnpkg.com/angular-sanitize/-/angular-sanitize-1.8.3.tgz#51378e990e78c7ecc1fb31cd68655aff690a3bf1"
   integrity sha512-2rxdqzlUVafUeWOwvY/FtyWk1pFTyCtzreeiTytG9m4smpuAEKaIJAjYeVwWsoV+nlTOcgpwV4W1OCmR+BQbUg==
 
-angular-ui-router@^1.0.30:
-  version "1.0.30"
-  resolved "https://registry.yarnpkg.com/angular-ui-router/-/angular-ui-router-1.0.30.tgz#de8a07fa1620fc5a979ee8448d0ded159792436f"
-  integrity sha512-8xMpxbOtCJbRnGR1fhbyZ5BhFXr3zs1L2ytXQiBACTJjot309QNFFCaWx0lDM2eVXp8qte4idigU9gwWdspmtQ==
+angular-ui-router@^0.4.3:
+  version "0.4.3"
+  resolved "https://registry.yarnpkg.com/angular-ui-router/-/angular-ui-router-0.4.3.tgz#6c29546fe50b8d2f74614dcb8660d6fc40d6e167"
+  integrity sha512-EGBG7G7ArFVkJPM+ZIgPKuMYuT16UQrr3zj3BEiXHKwxss867bGt3u7QD9g4BxR+K2qQOSWok6JGvgTWXAko3A==
   dependencies:
-    "@uirouter/core" "6.0.8"
+    angular "^1.0.8"
 
 angular-uuid@^0.0.4:
   version "0.0.4"
   resolved "https://registry.yarnpkg.com/angular-uuid/-/angular-uuid-0.0.4.tgz#87a860ca1d36ae389f7ec60fd04366edc0e3584d"
   integrity sha512-4dHBWMB56blHrh25cPS+SFDhWIwmvqyPfqCPwYX32rBwwVQloKPmhZ7+HIpmAGj95ViKAstEHDJcOf452zUnsg==
 
-angular@^1.7.2:
+angular@^1.0.8, angular@^1.7.2:
   version "1.8.3"
   resolved "https://registry.yarnpkg.com/angular/-/angular-1.8.3.tgz#851ad75d5163c105a7e329555ef70c90aa706894"
   integrity sha512-5qjkWIQQVsHj4Sb5TcEs4WZWpFeVFHXwxEBHUhrny41D8UrBAd6T/6nPPAsLngJCReIOqi95W3mxdveveutpZw==


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
Upgrading angular-ui-router causes an error when clicking on the new campaign button:
![Screenshot 2024-05-22 at 14 47 39](https://github.com/guardian/memsub-promotions/assets/181371/c3a06b23-c291-46a0-aabb-b07e190d04f2)

The error is 
```
stateService.js:35 Error: Transition Rejection($id: 1 type: 4, message: This transition is invalid, detail: The following parameter values are not valid for state 'editCampaign': [code:undefined])
    at invalidTransitionHook (invalidTransition.js:10:1)
    at invokeCallback (transitionHook.js:90:44)
    at TransitionHook.invokeHook (transitionHook.js:95:1)
    at TransitionHook.invokeHooks (transitionHook.js:63:1)
    at Transition.run (transition.js:600:23)
    at StateService.transitionTo (stateService.js:369:1)
    at StateService.go (stateService.js:265:1)
    at stateDirectives.js:55:1
    at angular.js:21765:1
    at TaskTracker.completeTask (angular.js:21403:1)
```

Reverting this upgrade for now to unblock business users