### PR TITLE
feat: add 3-tier product rate plans to promotions tool

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ project/project/
 /.bloop/
 /project/.bloop/
 /project/metals.sbt
+.vscode

--- a/app/com/gu/aws/AwsS3Client.scala
+++ b/app/com/gu/aws/AwsS3Client.scala
@@ -1,5 +1,6 @@
 package com.gu.aws
 
+import com.amazonaws.regions.Regions
 import com.amazonaws.services.s3.model.{GetObjectRequest, S3ObjectInputStream}
 import com.amazonaws.services.s3.{AmazonS3, AmazonS3Client}
 import com.gu.monitoring.SafeLogger
@@ -13,9 +14,11 @@ import scala.util.{Failure, Success, Try}
 
 object AwsS3 extends StrictLogging {
 
-  lazy val client = AmazonS3Client.builder.withCredentials(CredentialsProvider).build()
+  lazy val client = AmazonS3Client.builder.withCredentials(CredentialsProvider).withRegion(Regions.EU_WEST_1).build()
 
-  def fetchObject(s3Client: AmazonS3, request: GetObjectRequest): Try[S3ObjectInputStream] = Try(s3Client.getObject(request).getObjectContent)
+  def fetchObject(s3Client: AmazonS3, request: GetObjectRequest): Try[S3ObjectInputStream] = Try(
+    s3Client.getObject(request).getObjectContent,
+  )
 
   def fetchJson(s3Client: AmazonS3, request: GetObjectRequest): String \/ JsValue = {
     logger.info(s"Getting file from S3. Bucket: ${request.getBucketName} | Key: ${request.getKey}")

--- a/app/com/gu/config/SupporterPlusRatePlanIds.scala
+++ b/app/com/gu/config/SupporterPlusRatePlanIds.scala
@@ -2,15 +2,33 @@ package com.gu.config
 
 import com.gu.memsub.Subscription.ProductRatePlanId
 
-case class SupporterPlusRatePlanIds(yearly: ProductRatePlanId, monthly: ProductRatePlanId)
-    extends ProductFamilyRatePlanIds {
-  override val productRatePlanIds: Set[ProductRatePlanId] = Set(yearly, monthly)
+case class SupporterPlusRatePlanIds(
+    yearly: ProductRatePlanId,
+    monthly: ProductRatePlanId,
+    guardianWeeklyRestOfWorldMonthly: ProductRatePlanId,
+    guardianWeeklyRestOfWorldAnnual: ProductRatePlanId,
+    guardianWeeklyDomesticAnnual: ProductRatePlanId,
+    guardianWeeklyDomesticMonthly: ProductRatePlanId,
+) extends ProductFamilyRatePlanIds {
+  override val productRatePlanIds: Set[ProductRatePlanId] =
+    Set(
+      yearly,
+      monthly,
+      guardianWeeklyRestOfWorldMonthly,
+      guardianWeeklyRestOfWorldAnnual,
+      guardianWeeklyDomesticAnnual,
+      guardianWeeklyDomesticMonthly,
+    )
 }
 
 object SupporterPlusRatePlanIds {
   def fromConfig(config: com.typesafe.config.Config): SupporterPlusRatePlanIds =
     SupporterPlusRatePlanIds(
       ProductRatePlanId(config.getString("yearly")),
-      ProductRatePlanId(config.getString("monthly"))
+      ProductRatePlanId(config.getString("monthly")),
+      ProductRatePlanId(config.getString(("guardianWeeklyRestOfWorldMonthly"))),
+      ProductRatePlanId(config.getString(("guardianWeeklyRestOfWorldAnnual"))),
+      ProductRatePlanId(config.getString(("guardianWeeklyDomesticAnnual"))),
+      ProductRatePlanId(config.getString(("guardianWeeklyDomesticMonthly"))),
     )
 }

--- a/app/com/gu/config/SupporterPlusRatePlanIds.scala
+++ b/app/com/gu/config/SupporterPlusRatePlanIds.scala
@@ -26,9 +26,9 @@ object SupporterPlusRatePlanIds {
     SupporterPlusRatePlanIds(
       ProductRatePlanId(config.getString("yearly")),
       ProductRatePlanId(config.getString("monthly")),
-      ProductRatePlanId(config.getString(("guardianWeeklyRestOfWorldMonthly"))),
-      ProductRatePlanId(config.getString(("guardianWeeklyRestOfWorldAnnual"))),
-      ProductRatePlanId(config.getString(("guardianWeeklyDomesticAnnual"))),
-      ProductRatePlanId(config.getString(("guardianWeeklyDomesticMonthly"))),
+      ProductRatePlanId(config.getString("guardianWeeklyRestOfWorldMonthly")),
+      ProductRatePlanId(config.getString("guardianWeeklyRestOfWorldAnnual")),
+      ProductRatePlanId(config.getString("guardianWeeklyDomesticAnnual")),
+      ProductRatePlanId(config.getString("guardianWeeklyDomesticMonthly")),
     )
 }

--- a/app/com/gu/memsub/subsv2/Plan.scala
+++ b/app/com/gu/memsub/subsv2/Plan.scala
@@ -200,8 +200,25 @@ object FrontendId {
   case object Introductory extends FrontendId { val name = "Introductory" }
   case object Free extends FrontendId { val name = "Free" }
   case object SixWeeks extends FrontendId { val name = "SixWeeks" }
+  case object ThirdTierMonthlyROW extends FrontendId { val name = "ThirdTierMonthlyROW" }
+  case object ThirdTierAnnualROW extends FrontendId { val name = "ThirdTierAnnualROW" }
+  case object ThirdTierAnnualDomestic extends FrontendId { val name = "ThirdTierAnnualDomestic" }
+  case object ThirdTierMonthlyDomestic extends FrontendId { val name = "ThirdTierMonthlyDomestic" }
 
-  val all = List(OneYear, ThreeMonths, Monthly, Quarterly, Yearly, Introductory, Free, SixWeeks)
+  val all = List(
+    OneYear,
+    ThreeMonths,
+    Monthly,
+    Quarterly,
+    Yearly,
+    Introductory,
+    Free,
+    SixWeeks,
+    ThirdTierMonthlyROW,
+    ThirdTierAnnualROW,
+    ThirdTierAnnualDomestic,
+    ThirdTierMonthlyDomestic,
+  )
 
   def get(jsonString: String): Option[FrontendId] =
     all.find(_.name == jsonString)
@@ -243,8 +260,22 @@ case class DigipackPlans(month: CatalogPlan.Digipack[Month.type], quarter: Catal
   lazy val plans = List(month, quarter, year)
 }
 
-case class SupporterPlusPlans(month: CatalogPlan.SupporterPlus[Month.type], year: CatalogPlan.SupporterPlus[Year.type]) {
-  lazy val plans = List(month, year)
+case class SupporterPlusPlans(
+  month: CatalogPlan.SupporterPlus[Month.type],
+  year: CatalogPlan.SupporterPlus[Year.type],
+  guardianWeeklyRestOfWorldMonthly: CatalogPlan.SupporterPlus[Month.type],
+  guardianWeeklyRestOfWorldAnnual: CatalogPlan.SupporterPlus[Year.type],
+  guardianWeeklyDomesticAnnual: CatalogPlan.SupporterPlus[Year.type],
+  guardianWeeklyDomesticMonthly: CatalogPlan.SupporterPlus[Month.type],
+) {
+  lazy val plans = List(
+    month,
+    year,
+    guardianWeeklyRestOfWorldMonthly,
+    guardianWeeklyRestOfWorldAnnual,
+    guardianWeeklyDomesticAnnual,
+    guardianWeeklyDomesticMonthly
+  )
 }
 
 case class WeeklyZoneBPlans(quarter: CatalogPlan.WeeklyZoneB[Quarter.type], year: CatalogPlan.WeeklyZoneB[Year.type], oneYear: CatalogPlan.WeeklyZoneB[OneYear.type]) {

--- a/app/com/gu/memsub/subsv2/services/CatalogService.scala
+++ b/app/com/gu/memsub/subsv2/services/CatalogService.scala
@@ -76,7 +76,11 @@ class CatalogService[M[_] : Monad](productIds: ProductIds, fetchCatalog: M[Strin
       ) (DigipackPlans)
     supporterPlus <- (
       one[SupporterPlus[Month.type]](plans, "Supporter Plus month", FrontendId.Monthly) |@|
-        one[SupporterPlus[Year.type]](plans, "Supporter Plus year", FrontendId.Yearly)
+        one[SupporterPlus[Year.type]](plans, "Supporter Plus year", FrontendId.Yearly) |@|
+        one[SupporterPlus[Month.type]](plans, "Guardian Weekly Rest Of World Monthly", FrontendId.ThirdTierMonthlyROW) |@|
+        one[SupporterPlus[Year.type]](plans, "Guardian Weekly Rest Of World Annual", FrontendId.ThirdTierAnnualROW) |@|
+        one[SupporterPlus[Year.type]](plans, "Guardian Weekly Domestic Annual", FrontendId.ThirdTierAnnualDomestic) |@|
+        one[SupporterPlus[Month.type]](plans, "Guardian Weekly Domestic Monthly", FrontendId.ThirdTierMonthlyDomestic)
       ) (SupporterPlusPlans)
     contributor <- one[Contributor](plans, "Contributor month", FrontendId.Monthly)
     voucher <- many[Voucher](plans, "Paper voucher")

--- a/app/controllers/RatePlanController.scala
+++ b/app/controllers/RatePlanController.scala
@@ -65,71 +65,83 @@ class RatePlanController(
   }
 
   def all = googleAuthAction {
-    Ok(Json.obj(
-      SupporterPlus.id -> Json.toJson(Seq(
-          RatePlan(supporterPlusIds.yearly, "Annual"),
-          RatePlan(supporterPlusIds.monthly, "Monthly"),
-      ).map(enhance)),
-      DigitalPack.id -> Json.toJson(Seq(
-        RatePlan(digipackIds.digitalPackMonthly, "Digital Pack monthly"),
-        RatePlan(digipackIds.digitalPackQuaterly, "Digital Pack quarterly"),
-        RatePlan(digipackIds.digitalPackYearly, "Digital Pack yearly")
-      ).map(enhance)),
-      Newspaper.id -> Json.toJson(Seq(
-        RatePlan(paperPlans.delivery.saturday, "Home Delivery Saturday"),
-        RatePlan(paperPlans.delivery.saturdayplus, "Home Delivery Saturday+"),
-        RatePlan(paperPlans.delivery.sunday, "Home Delivery Sunday"),
-        RatePlan(paperPlans.delivery.sundayplus, "Home Delivery Sunday+"),
-        RatePlan(paperPlans.delivery.weekend, "Home Delivery Weekend"),
-        RatePlan(paperPlans.delivery.weekendplus, "Home Delivery Weekend+"),
-        RatePlan(paperPlans.delivery.sixday, "Home Delivery Sixday"),
-        RatePlan(paperPlans.delivery.sixdayplus, "Home Delivery Sixday+"),
-        RatePlan(paperPlans.delivery.everyday, "Home Delivery Everyday"),
-        RatePlan(paperPlans.delivery.everydayplus, "Home Delivery Everyday+"),
-        RatePlan(paperPlans.nationalDelivery.weekend, "National Delivery Weekend"),
-        RatePlan(paperPlans.nationalDelivery.sixday, "National Delivery Sixday"),
-        RatePlan(paperPlans.nationalDelivery.everyday, "National Delivery Everyday"),
-        RatePlan(paperPlans.voucher.saturday, "Voucher Saturday"),
-        RatePlan(paperPlans.voucher.saturdayplus, "Voucher Saturday+"),
-        RatePlan(paperPlans.voucher.sunday, "Voucher Sunday"),
-        RatePlan(paperPlans.voucher.sundayplus, "Voucher Sunday+"),
-        RatePlan(paperPlans.voucher.weekend, "Voucher Weekend"),
-        RatePlan(paperPlans.voucher.weekendplus, "Voucher Weekend+"),
-        RatePlan(paperPlans.voucher.sixday, "Voucher Sixday"),
-        RatePlan(paperPlans.voucher.sixdayplus, "Voucher Sixday+"),
-        RatePlan(paperPlans.voucher.everyday, "Voucher Everyday"),
-        RatePlan(paperPlans.voucher.everydayplus, "Voucher Everyday+"),
-        RatePlan(paperPlans.digitalVoucher.saturday, "Subscription Card Saturday"),
-        RatePlan(paperPlans.digitalVoucher.saturdayplus, "Subscription Card Saturday+"),
-        RatePlan(paperPlans.digitalVoucher.sunday, "Subscription Card Sunday"),
-        RatePlan(paperPlans.digitalVoucher.sundayplus, "Subscription Card Sunday+"),
-        RatePlan(paperPlans.digitalVoucher.weekend, "Subscription Card Weekend"),
-        RatePlan(paperPlans.digitalVoucher.weekendplus, "Subscription Card Weekend+"),
-        RatePlan(paperPlans.digitalVoucher.sixday, "Subscription Card Sixday"),
-        RatePlan(paperPlans.digitalVoucher.sixdayplus, "Subscription Card Sixday+"),
-        RatePlan(paperPlans.digitalVoucher.everyday, "Subscription Card Everyday"),
-        RatePlan(paperPlans.digitalVoucher.everydayplus, "Subscription Card Everyday+")
-      ).map(enhance)),
-      GuardianWeekly.id -> Json.toJson(
-        (
-        Seq(
-          RatePlan(weeklyPlans.domestic.yearly, "Domestic Annual"),
-          RatePlan(weeklyPlans.row.yearly, "ROW Annual"),
-          RatePlan(weeklyPlans.domestic.quarterly, "Domestic Quarterly"),
-          RatePlan(weeklyPlans.row.quarterly, "ROW Quarterly"),
-          RatePlan(weeklyPlans.domestic.monthly, "Domestic Monthly"),
-          RatePlan(weeklyPlans.row.monthly, "ROW Monthly")
-        )
-          ++ weeklyPlans.domestic.six.map(id => RatePlan(id, "Domestic 6-for-6"))
-          ++ weeklyPlans.row.six.map(id => RatePlan(id, "ROW 6-for-6"))
-          ++ weeklyPlans.domestic.oneYear.map(id => RatePlan(id, "Domestic 1 year fixed"))
-          ++ weeklyPlans.row.oneYear.map(id => RatePlan(id, "ROW 1 year fixed"))
-          ++ weeklyPlans.domestic.threeMonth.map(id => RatePlan(id, "Domestic 3 month fixed"))
-          ++ weeklyPlans.row.threeMonth.map(id => RatePlan(id, "ROW 3 month fixed"))
-        )
-        .map(enhance)
-      )
-    ))
+    Ok(
+      Json.obj(
+        SupporterPlus.id -> Json.toJson(
+          Seq(
+            RatePlan(supporterPlusIds.yearly, "Annual"),
+            RatePlan(supporterPlusIds.monthly, "Monthly"),
+            RatePlan(supporterPlusIds.guardianWeeklyRestOfWorldMonthly, "Guardian Weekly Rest Of World Monthly"),
+            RatePlan(supporterPlusIds.guardianWeeklyRestOfWorldAnnual, "Guardian Weekly Rest Of World Annual"),
+            RatePlan(supporterPlusIds.guardianWeeklyDomesticAnnual, "Guardian Weekly Domestic Annual"),
+            RatePlan(supporterPlusIds.guardianWeeklyDomesticMonthly, "Guardian Weekly Domestic Monthly"),
+          ).map(enhance),
+        ),
+        DigitalPack.id -> Json.toJson(
+          Seq(
+            RatePlan(digipackIds.digitalPackMonthly, "Digital Pack monthly"),
+            RatePlan(digipackIds.digitalPackQuaterly, "Digital Pack quarterly"),
+            RatePlan(digipackIds.digitalPackYearly, "Digital Pack yearly"),
+          ).map(enhance),
+        ),
+        Newspaper.id -> Json.toJson(
+          Seq(
+            RatePlan(paperPlans.delivery.saturday, "Home Delivery Saturday"),
+            RatePlan(paperPlans.delivery.saturdayplus, "Home Delivery Saturday+"),
+            RatePlan(paperPlans.delivery.sunday, "Home Delivery Sunday"),
+            RatePlan(paperPlans.delivery.sundayplus, "Home Delivery Sunday+"),
+            RatePlan(paperPlans.delivery.weekend, "Home Delivery Weekend"),
+            RatePlan(paperPlans.delivery.weekendplus, "Home Delivery Weekend+"),
+            RatePlan(paperPlans.delivery.sixday, "Home Delivery Sixday"),
+            RatePlan(paperPlans.delivery.sixdayplus, "Home Delivery Sixday+"),
+            RatePlan(paperPlans.delivery.everyday, "Home Delivery Everyday"),
+            RatePlan(paperPlans.delivery.everydayplus, "Home Delivery Everyday+"),
+            RatePlan(paperPlans.nationalDelivery.weekend, "National Delivery Weekend"),
+            RatePlan(paperPlans.nationalDelivery.sixday, "National Delivery Sixday"),
+            RatePlan(paperPlans.nationalDelivery.everyday, "National Delivery Everyday"),
+            RatePlan(paperPlans.voucher.saturday, "Voucher Saturday"),
+            RatePlan(paperPlans.voucher.saturdayplus, "Voucher Saturday+"),
+            RatePlan(paperPlans.voucher.sunday, "Voucher Sunday"),
+            RatePlan(paperPlans.voucher.sundayplus, "Voucher Sunday+"),
+            RatePlan(paperPlans.voucher.weekend, "Voucher Weekend"),
+            RatePlan(paperPlans.voucher.weekendplus, "Voucher Weekend+"),
+            RatePlan(paperPlans.voucher.sixday, "Voucher Sixday"),
+            RatePlan(paperPlans.voucher.sixdayplus, "Voucher Sixday+"),
+            RatePlan(paperPlans.voucher.everyday, "Voucher Everyday"),
+            RatePlan(paperPlans.voucher.everydayplus, "Voucher Everyday+"),
+            RatePlan(paperPlans.digitalVoucher.saturday, "Subscription Card Saturday"),
+            RatePlan(paperPlans.digitalVoucher.saturdayplus, "Subscription Card Saturday+"),
+            RatePlan(paperPlans.digitalVoucher.sunday, "Subscription Card Sunday"),
+            RatePlan(paperPlans.digitalVoucher.sundayplus, "Subscription Card Sunday+"),
+            RatePlan(paperPlans.digitalVoucher.weekend, "Subscription Card Weekend"),
+            RatePlan(paperPlans.digitalVoucher.weekendplus, "Subscription Card Weekend+"),
+            RatePlan(paperPlans.digitalVoucher.sixday, "Subscription Card Sixday"),
+            RatePlan(paperPlans.digitalVoucher.sixdayplus, "Subscription Card Sixday+"),
+            RatePlan(paperPlans.digitalVoucher.everyday, "Subscription Card Everyday"),
+            RatePlan(paperPlans.digitalVoucher.everydayplus, "Subscription Card Everyday+"),
+          ).map(enhance),
+        ),
+        GuardianWeekly.id -> Json.toJson(
+          (
+            Seq(
+              RatePlan(weeklyPlans.domestic.yearly, "Domestic Annual"),
+              RatePlan(weeklyPlans.row.yearly, "ROW Annual"),
+              RatePlan(weeklyPlans.domestic.quarterly, "Domestic Quarterly"),
+              RatePlan(weeklyPlans.row.quarterly, "ROW Quarterly"),
+              RatePlan(weeklyPlans.domestic.monthly, "Domestic Monthly"),
+              RatePlan(weeklyPlans.row.monthly, "ROW Monthly"),
+            )
+              ++ weeklyPlans.domestic.six.map(id => RatePlan(id, "Domestic 6-for-6"))
+              ++ weeklyPlans.row.six.map(id => RatePlan(id, "ROW 6-for-6"))
+              ++ weeklyPlans.domestic.oneYear.map(id => RatePlan(id, "Domestic 1 year fixed"))
+              ++ weeklyPlans.row.oneYear.map(id => RatePlan(id, "ROW 1 year fixed"))
+              ++ weeklyPlans.domestic.threeMonth.map(id => RatePlan(id, "Domestic 3 month fixed"))
+              ++ weeklyPlans.row.threeMonth.map(id => RatePlan(id, "ROW 3 month fixed"))
+          )
+            .map(enhance),
+        ),
+      ),
+    )
   }
 }
 

--- a/app/controllers/RatePlanController.scala
+++ b/app/controllers/RatePlanController.scala
@@ -65,83 +65,75 @@ class RatePlanController(
   }
 
   def all = googleAuthAction {
-    Ok(
-      Json.obj(
-        SupporterPlus.id -> Json.toJson(
-          Seq(
-            RatePlan(supporterPlusIds.yearly, "Annual"),
-            RatePlan(supporterPlusIds.monthly, "Monthly"),
-            RatePlan(supporterPlusIds.guardianWeeklyRestOfWorldMonthly, "Guardian Weekly Rest Of World Monthly"),
-            RatePlan(supporterPlusIds.guardianWeeklyRestOfWorldAnnual, "Guardian Weekly Rest Of World Annual"),
-            RatePlan(supporterPlusIds.guardianWeeklyDomesticAnnual, "Guardian Weekly Domestic Annual"),
-            RatePlan(supporterPlusIds.guardianWeeklyDomesticMonthly, "Guardian Weekly Domestic Monthly"),
-          ).map(enhance),
-        ),
-        DigitalPack.id -> Json.toJson(
-          Seq(
-            RatePlan(digipackIds.digitalPackMonthly, "Digital Pack monthly"),
-            RatePlan(digipackIds.digitalPackQuaterly, "Digital Pack quarterly"),
-            RatePlan(digipackIds.digitalPackYearly, "Digital Pack yearly"),
-          ).map(enhance),
-        ),
-        Newspaper.id -> Json.toJson(
-          Seq(
-            RatePlan(paperPlans.delivery.saturday, "Home Delivery Saturday"),
-            RatePlan(paperPlans.delivery.saturdayplus, "Home Delivery Saturday+"),
-            RatePlan(paperPlans.delivery.sunday, "Home Delivery Sunday"),
-            RatePlan(paperPlans.delivery.sundayplus, "Home Delivery Sunday+"),
-            RatePlan(paperPlans.delivery.weekend, "Home Delivery Weekend"),
-            RatePlan(paperPlans.delivery.weekendplus, "Home Delivery Weekend+"),
-            RatePlan(paperPlans.delivery.sixday, "Home Delivery Sixday"),
-            RatePlan(paperPlans.delivery.sixdayplus, "Home Delivery Sixday+"),
-            RatePlan(paperPlans.delivery.everyday, "Home Delivery Everyday"),
-            RatePlan(paperPlans.delivery.everydayplus, "Home Delivery Everyday+"),
-            RatePlan(paperPlans.nationalDelivery.weekend, "National Delivery Weekend"),
-            RatePlan(paperPlans.nationalDelivery.sixday, "National Delivery Sixday"),
-            RatePlan(paperPlans.nationalDelivery.everyday, "National Delivery Everyday"),
-            RatePlan(paperPlans.voucher.saturday, "Voucher Saturday"),
-            RatePlan(paperPlans.voucher.saturdayplus, "Voucher Saturday+"),
-            RatePlan(paperPlans.voucher.sunday, "Voucher Sunday"),
-            RatePlan(paperPlans.voucher.sundayplus, "Voucher Sunday+"),
-            RatePlan(paperPlans.voucher.weekend, "Voucher Weekend"),
-            RatePlan(paperPlans.voucher.weekendplus, "Voucher Weekend+"),
-            RatePlan(paperPlans.voucher.sixday, "Voucher Sixday"),
-            RatePlan(paperPlans.voucher.sixdayplus, "Voucher Sixday+"),
-            RatePlan(paperPlans.voucher.everyday, "Voucher Everyday"),
-            RatePlan(paperPlans.voucher.everydayplus, "Voucher Everyday+"),
-            RatePlan(paperPlans.digitalVoucher.saturday, "Subscription Card Saturday"),
-            RatePlan(paperPlans.digitalVoucher.saturdayplus, "Subscription Card Saturday+"),
-            RatePlan(paperPlans.digitalVoucher.sunday, "Subscription Card Sunday"),
-            RatePlan(paperPlans.digitalVoucher.sundayplus, "Subscription Card Sunday+"),
-            RatePlan(paperPlans.digitalVoucher.weekend, "Subscription Card Weekend"),
-            RatePlan(paperPlans.digitalVoucher.weekendplus, "Subscription Card Weekend+"),
-            RatePlan(paperPlans.digitalVoucher.sixday, "Subscription Card Sixday"),
-            RatePlan(paperPlans.digitalVoucher.sixdayplus, "Subscription Card Sixday+"),
-            RatePlan(paperPlans.digitalVoucher.everyday, "Subscription Card Everyday"),
-            RatePlan(paperPlans.digitalVoucher.everydayplus, "Subscription Card Everyday+"),
-          ).map(enhance),
-        ),
-        GuardianWeekly.id -> Json.toJson(
-          (
-            Seq(
-              RatePlan(weeklyPlans.domestic.yearly, "Domestic Annual"),
-              RatePlan(weeklyPlans.row.yearly, "ROW Annual"),
-              RatePlan(weeklyPlans.domestic.quarterly, "Domestic Quarterly"),
-              RatePlan(weeklyPlans.row.quarterly, "ROW Quarterly"),
-              RatePlan(weeklyPlans.domestic.monthly, "Domestic Monthly"),
-              RatePlan(weeklyPlans.row.monthly, "ROW Monthly"),
-            )
-              ++ weeklyPlans.domestic.six.map(id => RatePlan(id, "Domestic 6-for-6"))
-              ++ weeklyPlans.row.six.map(id => RatePlan(id, "ROW 6-for-6"))
-              ++ weeklyPlans.domestic.oneYear.map(id => RatePlan(id, "Domestic 1 year fixed"))
-              ++ weeklyPlans.row.oneYear.map(id => RatePlan(id, "ROW 1 year fixed"))
-              ++ weeklyPlans.domestic.threeMonth.map(id => RatePlan(id, "Domestic 3 month fixed"))
-              ++ weeklyPlans.row.threeMonth.map(id => RatePlan(id, "ROW 3 month fixed"))
-          )
-            .map(enhance),
-        ),
-      ),
-    )
+    Ok(Json.obj(
+      SupporterPlus.id -> Json.toJson(Seq(
+          RatePlan(supporterPlusIds.yearly, "Annual"),
+          RatePlan(supporterPlusIds.monthly, "Monthly"),
+          RatePlan(supporterPlusIds.guardianWeeklyRestOfWorldMonthly, "Guardian Weekly Rest Of World Monthly"),
+          RatePlan(supporterPlusIds.guardianWeeklyRestOfWorldAnnual, "Guardian Weekly Rest Of World Annual"),
+          RatePlan(supporterPlusIds.guardianWeeklyDomesticAnnual, "Guardian Weekly Domestic Annual"),
+          RatePlan(supporterPlusIds.guardianWeeklyDomesticMonthly, "Guardian Weekly Domestic Monthly"),
+      ).map(enhance)),
+      DigitalPack.id -> Json.toJson(Seq(
+        RatePlan(digipackIds.digitalPackMonthly, "Digital Pack monthly"),
+        RatePlan(digipackIds.digitalPackQuaterly, "Digital Pack quarterly"),
+        RatePlan(digipackIds.digitalPackYearly, "Digital Pack yearly")
+      ).map(enhance)),
+      Newspaper.id -> Json.toJson(Seq(
+        RatePlan(paperPlans.delivery.saturday, "Home Delivery Saturday"),
+        RatePlan(paperPlans.delivery.saturdayplus, "Home Delivery Saturday+"),
+        RatePlan(paperPlans.delivery.sunday, "Home Delivery Sunday"),
+        RatePlan(paperPlans.delivery.sundayplus, "Home Delivery Sunday+"),
+        RatePlan(paperPlans.delivery.weekend, "Home Delivery Weekend"),
+        RatePlan(paperPlans.delivery.weekendplus, "Home Delivery Weekend+"),
+        RatePlan(paperPlans.delivery.sixday, "Home Delivery Sixday"),
+        RatePlan(paperPlans.delivery.sixdayplus, "Home Delivery Sixday+"),
+        RatePlan(paperPlans.delivery.everyday, "Home Delivery Everyday"),
+        RatePlan(paperPlans.delivery.everydayplus, "Home Delivery Everyday+"),
+        RatePlan(paperPlans.nationalDelivery.weekend, "National Delivery Weekend"),
+        RatePlan(paperPlans.nationalDelivery.sixday, "National Delivery Sixday"),
+        RatePlan(paperPlans.nationalDelivery.everyday, "National Delivery Everyday"),
+        RatePlan(paperPlans.voucher.saturday, "Voucher Saturday"),
+        RatePlan(paperPlans.voucher.saturdayplus, "Voucher Saturday+"),
+        RatePlan(paperPlans.voucher.sunday, "Voucher Sunday"),
+        RatePlan(paperPlans.voucher.sundayplus, "Voucher Sunday+"),
+        RatePlan(paperPlans.voucher.weekend, "Voucher Weekend"),
+        RatePlan(paperPlans.voucher.weekendplus, "Voucher Weekend+"),
+        RatePlan(paperPlans.voucher.sixday, "Voucher Sixday"),
+        RatePlan(paperPlans.voucher.sixdayplus, "Voucher Sixday+"),
+        RatePlan(paperPlans.voucher.everyday, "Voucher Everyday"),
+        RatePlan(paperPlans.voucher.everydayplus, "Voucher Everyday+"),
+        RatePlan(paperPlans.digitalVoucher.saturday, "Subscription Card Saturday"),
+        RatePlan(paperPlans.digitalVoucher.saturdayplus, "Subscription Card Saturday+"),
+        RatePlan(paperPlans.digitalVoucher.sunday, "Subscription Card Sunday"),
+        RatePlan(paperPlans.digitalVoucher.sundayplus, "Subscription Card Sunday+"),
+        RatePlan(paperPlans.digitalVoucher.weekend, "Subscription Card Weekend"),
+        RatePlan(paperPlans.digitalVoucher.weekendplus, "Subscription Card Weekend+"),
+        RatePlan(paperPlans.digitalVoucher.sixday, "Subscription Card Sixday"),
+        RatePlan(paperPlans.digitalVoucher.sixdayplus, "Subscription Card Sixday+"),
+        RatePlan(paperPlans.digitalVoucher.everyday, "Subscription Card Everyday"),
+        RatePlan(paperPlans.digitalVoucher.everydayplus, "Subscription Card Everyday+")
+      ).map(enhance)),
+      GuardianWeekly.id -> Json.toJson(
+        (
+        Seq(
+          RatePlan(weeklyPlans.domestic.yearly, "Domestic Annual"),
+          RatePlan(weeklyPlans.row.yearly, "ROW Annual"),
+          RatePlan(weeklyPlans.domestic.quarterly, "Domestic Quarterly"),
+          RatePlan(weeklyPlans.row.quarterly, "ROW Quarterly"),
+          RatePlan(weeklyPlans.domestic.monthly, "Domestic Monthly"),
+          RatePlan(weeklyPlans.row.monthly, "ROW Monthly")
+        )
+          ++ weeklyPlans.domestic.six.map(id => RatePlan(id, "Domestic 6-for-6"))
+          ++ weeklyPlans.row.six.map(id => RatePlan(id, "ROW 6-for-6"))
+          ++ weeklyPlans.domestic.oneYear.map(id => RatePlan(id, "Domestic 1 year fixed"))
+          ++ weeklyPlans.row.oneYear.map(id => RatePlan(id, "ROW 1 year fixed"))
+          ++ weeklyPlans.domestic.threeMonth.map(id => RatePlan(id, "Domestic 3 month fixed"))
+          ++ weeklyPlans.row.threeMonth.map(id => RatePlan(id, "ROW 3 month fixed"))
+        )
+        .map(enhance)
+      )
+    ))
   }
 }
 

--- a/conf/touchpoint.CODE.conf
+++ b/conf/touchpoint.CODE.conf
@@ -105,6 +105,10 @@ touchpoint.backend.environments {
                 supporterPlus={
                     monthly="8ad08cbd8586721c01858804e3275376"
                     yearly="8ad08e1a8586721801858805663f6fab"
+                    guardianWeeklyRestOfWorldMonthly="8ad097b48f006681018f05a2c0fb0227"
+                    guardianWeeklyRestOfWorldAnnual="8ad097b48f006681018f05a0496e01f4"
+                    guardianWeeklyDomesticAnnual="8ad097b48f006681018f059b755e0140"
+                    guardianWeeklyDomesticMonthly="8ad081dd8ef57784018ef6e159224bfa"
                 }
             }
             invoiceTemplateIds {

--- a/conf/touchpoint.PROD.conf
+++ b/conf/touchpoint.PROD.conf
@@ -90,6 +90,10 @@ touchpoint.backend.environments {
                 supporterPlus={
                     monthly="8a128ed885fc6ded018602296ace3eb8"
                     yearly="8a128ed885fc6ded01860228f77e3d5a"
+                    guardianWeeklyRestOfWorldMonthly="8a1281f38f518d11018f52a599806a65"
+                    guardianWeeklyRestOfWorldAnnual="8a1292628f51a923018f52a324e45710"
+                    guardianWeeklyDomesticAnnual="8a1282048f518d08018f529ead0f3d91"
+                    guardianWeeklyDomesticMonthly="8a1288a38f518d01018f529a04443172"
                 }
             }
             invoiceTemplateIds {


### PR DESCRIPTION
## What does this change?

This adds the 4 new 3-tier product rate plans to the Promo Tool.

Updated list of product rate plans for Supporter Plus:
- Annual
- Monthly
- Guardian Weekly Rest Of World Monthly (NEW)
- Guardian Weekly Rest Of World Annual (NEW)
- Guardian Weekly Domestic Annual (NEW)
- Guardian Weekly Domestic Monthly (NEW)

## How to test

- Access the Promo Tool in CODE [here](https://promo.code.memsub-promotions.gutools.co.uk)
- Select from the top left dropdown "Supporter Plus"
- Create new promotion
- See the new product rate plans available

![Screenshot 2024-06-04 at 16 31 02](https://github.com/guardian/memsub-promotions/assets/39066365/0f0db057-6028-4a72-90fd-5f8b03eff7bc)

- Example of promotion with new product rate plan on CODE [here](https://promo.thegulocal.com/#!/promotion/9c3594cb-139c-4c02-9e29-ae41e201590f)

## How can we measure success?

The reader revenue team are able to create promotion codes with the new 3-tier product rate plans.