### PR TITLE
Add TierThree product and remove SupporterPlus ratePLans

### DIFF
--- a/app/com/gu/config/SubsV2ProductIds.scala
+++ b/app/com/gu/config/SubsV2ProductIds.scala
@@ -16,6 +16,7 @@ object SubsV2ProductIds {
     digitalVoucher = ProductId(config.getString("subscriptions.digitalVoucher")),
     digipack = ProductId(config.getString("subscriptions.digipack")),
     supporterPlus = ProductId(config.getString("subscriptions.supporterPlus")),
+    tierThree = ProductId(config.getString("subscriptions.tierThree")),
     contributor = ProductId(config.getString("contributions.contributor"))
   )
 }

--- a/app/com/gu/config/SupporterPlusRatePlanIds.scala
+++ b/app/com/gu/config/SupporterPlusRatePlanIds.scala
@@ -5,19 +5,11 @@ import com.gu.memsub.Subscription.ProductRatePlanId
 case class SupporterPlusRatePlanIds(
     yearly: ProductRatePlanId,
     monthly: ProductRatePlanId,
-    guardianWeeklyRestOfWorldMonthly: ProductRatePlanId,
-    guardianWeeklyRestOfWorldAnnual: ProductRatePlanId,
-    guardianWeeklyDomesticAnnual: ProductRatePlanId,
-    guardianWeeklyDomesticMonthly: ProductRatePlanId,
 ) extends ProductFamilyRatePlanIds {
   override val productRatePlanIds: Set[ProductRatePlanId] =
     Set(
       yearly,
       monthly,
-      guardianWeeklyRestOfWorldMonthly,
-      guardianWeeklyRestOfWorldAnnual,
-      guardianWeeklyDomesticAnnual,
-      guardianWeeklyDomesticMonthly,
     )
 }
 
@@ -26,9 +18,5 @@ object SupporterPlusRatePlanIds {
     SupporterPlusRatePlanIds(
       ProductRatePlanId(config.getString("yearly")),
       ProductRatePlanId(config.getString("monthly")),
-      ProductRatePlanId(config.getString("guardianWeeklyRestOfWorldMonthly")),
-      ProductRatePlanId(config.getString("guardianWeeklyRestOfWorldAnnual")),
-      ProductRatePlanId(config.getString("guardianWeeklyDomesticAnnual")),
-      ProductRatePlanId(config.getString("guardianWeeklyDomesticMonthly")),
     )
 }

--- a/app/com/gu/config/TierThreeRatePlanIds.scala
+++ b/app/com/gu/config/TierThreeRatePlanIds.scala
@@ -1,0 +1,28 @@
+package com.gu.config
+
+import com.gu.memsub.Subscription.ProductRatePlanId
+
+case class TierThreeRatePlanIds(
+    domesticMonthly: ProductRatePlanId,
+    domesticAnnual: ProductRatePlanId,
+    restOfWorldMonthly: ProductRatePlanId,
+    restOfWorldAnnual: ProductRatePlanId,
+) extends ProductFamilyRatePlanIds {
+  override val productRatePlanIds: Set[ProductRatePlanId] =
+    Set(
+      domesticMonthly,
+      domesticAnnual,
+      restOfWorldMonthly,
+      restOfWorldAnnual,
+    )
+}
+
+object TierThreeRatePlanIds {
+  def fromConfig(config: com.typesafe.config.Config): TierThreeRatePlanIds =
+    TierThreeRatePlanIds(
+      ProductRatePlanId(config.getString("domesticMonthly")),
+      ProductRatePlanId(config.getString("domesticAnnual")),
+      ProductRatePlanId(config.getString("restOfWorldMonthly")),
+      ProductRatePlanId(config.getString("restOfWorldAnnual")),
+    )
+}

--- a/app/com/gu/memsub/ProductFamily.scala
+++ b/app/com/gu/memsub/ProductFamily.scala
@@ -2,6 +2,7 @@ package com.gu.memsub
 
 import scalaz.syntax.std.option._
 import scalaz.syntax.std.boolean._
+import com.gu.memsub.Product.TierThree
 
 sealed trait ProductFamily {
   val id: String
@@ -50,6 +51,9 @@ object Product {
   case object SupporterPlus extends ContentSubscription {
     val name = "supporterPlus"
   }
+  case object TierThree extends ContentSubscription {
+    val name = "tierThree"
+  }
   case object Digipack extends ContentSubscription {
     val name = "digitalpack"
   }
@@ -89,6 +93,7 @@ object Product {
   def fromId(id: String): Option[Product] = id match {
     case Digipack.name => Some(Digipack)
     case SupporterPlus.name => Some(SupporterPlus)
+    case TierThree.name => Some(TierThree)
     case Delivery.name => Some(Delivery)
     case NationalDelivery.name => Some(NationalDelivery)
     case Voucher.name => Some(Voucher)
@@ -104,6 +109,7 @@ object Product {
   type GuardianPatron = GuardianPatron.type
   type ZDigipack = Digipack.type
   type SupporterPlus = SupporterPlus.type
+  type TierThree = TierThree.type
   type Delivery = Delivery.type
   type NationalDelivery = NationalDelivery.type
   type Voucher = Voucher.type
@@ -127,6 +133,7 @@ object Benefit {
   def fromId(id: String): Option[Benefit] =
     PaperDay.fromId(id) orElse
     (id == SupporterPlus.id).option(SupporterPlus) orElse
+    (id == TierThree.id).option(TierThree) orElse
     (id == Digipack.id).option(Digipack) orElse
     (id == Adjustment.id).option(Adjustment) orElse
     (id == Contributor.id).option(Contributor) orElse
@@ -172,6 +179,11 @@ object Benefit {
   object SupporterPlus extends Benefit {
     override val id = "Supporter Plus"
     override val isPhysical: Boolean = false
+  }
+
+  object TierThree extends Benefit {
+    override val id = "tierThree"
+    override val isPhysical: Boolean = true
   }
 
   object Weekly extends Benefit {

--- a/app/com/gu/memsub/promo/Formatters.scala
+++ b/app/com/gu/memsub/promo/Formatters.scala
@@ -10,7 +10,7 @@ import io.lemonlabs.uri.Uri
 import org.joda.time.{DateTime, Days}
 import play.api.libs.functional.syntax._
 import play.api.libs.json._
-import com.gu.memsub.promo.CampaignGroup.{DigitalPack, GuardianWeekly, Newspaper, SupporterPlus}
+import com.gu.memsub.promo.CampaignGroup.{DigitalPack, GuardianWeekly, Newspaper, SupporterPlus, TierThree}
 
 object Formatters {
 
@@ -119,6 +119,7 @@ object Formatters {
         // Supports the legacy serialisations of productFamily key as the identifier of a LandingPage type
         override def reads(json: JsValue): JsResult[LandingPage] = (json \ "productFamily").toOption orElse (json \ "type").toOption match {
           case Some(JsString(SupporterPlus.id))  => Json.reads[SupporterPlusLandingPage].reads(json)
+          case Some(JsString(TierThree.id))  => Json.reads[TierThreeLandingPage].reads(json)
           case Some(JsString(DigitalPack.id))  => Json.reads[DigitalPackLandingPage].reads(json)
           case Some(JsString(Newspaper.id))  => Json.reads[NewspaperLandingPage].reads(json)
           case Some(JsString(GuardianWeekly.id)) => Json.reads[WeeklyLandingPage].reads(json)
@@ -129,6 +130,7 @@ object Formatters {
         def writes(in: LandingPage): JsObject = {
           in match {
             case slp: SupporterPlusLandingPage => Json.writes[SupporterPlusLandingPage].writes(slp) ++ Json.obj("type" -> SupporterPlus.id)
+            case tlp: TierThreeLandingPage => Json.writes[TierThreeLandingPage].writes(tlp) ++ Json.obj("type" -> TierThree.id)
             case dlp: DigitalPackLandingPage => Json.writes[DigitalPackLandingPage].writes(dlp) ++ Json.obj("type" -> DigitalPack.id)
             case nlp: NewspaperLandingPage => Json.writes[NewspaperLandingPage].writes(nlp) ++ Json.obj("type" -> Newspaper.id)
             case wlp: WeeklyLandingPage => Json.writes[WeeklyLandingPage].writes(wlp) ++ Json.obj("type" -> GuardianWeekly.id)
@@ -138,6 +140,7 @@ object Formatters {
     )
 
     implicit val supporterPlusLandingPageFormat = Json.format[SupporterPlusLandingPage]
+    implicit val tierThreeLandingPageLandingPageFormat = Json.format[TierThreeLandingPage]
     implicit val digitalpackLandingPageFormat = Json.format[DigitalPackLandingPage]
     implicit val newspaperLandingPageFormat = Json.format[NewspaperLandingPage]
 

--- a/app/com/gu/memsub/promo/Promotion.scala
+++ b/app/com/gu/memsub/promo/Promotion.scala
@@ -34,6 +34,9 @@ object CampaignGroup {
   case object SupporterPlus extends CampaignGroup {
     override val id = "supporterPlus"
   }
+  case object TierThree extends CampaignGroup {
+    override val id = "tierThree"
+  }
   case object DigitalPack extends CampaignGroup {
     override val id = "digitalpack"
   }
@@ -47,6 +50,7 @@ object CampaignGroup {
   def fromId(id: String): Option[CampaignGroup] = id match {
     case DigitalPack.id => Some(DigitalPack)
     case SupporterPlus.id => Some(SupporterPlus)
+    case TierThree.id => Some(TierThree)
     case Newspaper.id => Some(Newspaper)
     case GuardianWeekly.id => Some(GuardianWeekly)
     case _ => None
@@ -145,6 +149,15 @@ case object Centre extends HeroImageAlignment
 case class HeroImage(image: ResponsiveImageGroup, alignment: HeroImageAlignment)
 
 case class SupporterPlusLandingPage(
+  title: Option[String],
+  subtitle: Option[String],
+  description: Option[String],
+  roundelHtml: Option[String],
+  heroImage: Option[HeroImage],
+  image: Option[ResponsiveImageGroup]
+) extends LandingPage
+
+case class TierThreeLandingPage(
   title: Option[String],
   subtitle: Option[String],
   description: Option[String],
@@ -274,6 +287,7 @@ object Promotion {
     def asNewspaper: PromoOpt[NewspaperLandingPage] = in.landingPage.collect { case f: NewspaperLandingPage => in.copy[A, CovariantId, NewspaperLandingPage](landingPage = (f)) }
     def asWeekly: PromoOpt[WeeklyLandingPage] = in.landingPage.collect { case f: WeeklyLandingPage => in.copy[A, CovariantId, WeeklyLandingPage](landingPage = (f)) }
     def asSupporterPlus: PromoOpt[SupporterPlusLandingPage] = in.landingPage.collect { case f: SupporterPlusLandingPage => in.copy[A, CovariantId, SupporterPlusLandingPage](landingPage = (f)) }
+    def asTierThree: PromoOpt[TierThreeLandingPage] = in.landingPage.collect { case f: TierThreeLandingPage => in.copy[A, CovariantId, TierThreeLandingPage](landingPage = (f)) }
   }
 
   def asAnyPromotion[T <: PromotionType[PromoContext]](in: Promotion[T, CovariantId, LandingPage]): AnyPromotion =

--- a/app/com/gu/memsub/subsv2/Plan.scala
+++ b/app/com/gu/memsub/subsv2/Plan.scala
@@ -231,6 +231,7 @@ object CatalogPlan {
 
   type Digipack[+B <: BillingPeriod] = CatalogPlan[Product.ZDigipack, PaidCharge[Digipack.type, B], Current]
   type SupporterPlus[+B <: BillingPeriod] = CatalogPlan[Product.SupporterPlus, SupporterPlusCharges, Current]
+  type TierThree[+B <: BillingPeriod] = CatalogPlan[Product.TierThree, TierThreeCharges, Current]
   type Delivery = CatalogPlan[Product.Delivery, PaperCharges, Current]
   type NationalDelivery = CatalogPlan[Product.NationalDelivery, PaperCharges, Current]
   type Voucher = CatalogPlan[Product.Voucher, PaperCharges, Current]
@@ -263,18 +264,24 @@ case class DigipackPlans(month: CatalogPlan.Digipack[Month.type], quarter: Catal
 case class SupporterPlusPlans(
   month: CatalogPlan.SupporterPlus[Month.type],
   year: CatalogPlan.SupporterPlus[Year.type],
-  guardianWeeklyRestOfWorldMonthly: CatalogPlan.SupporterPlus[Month.type],
-  guardianWeeklyRestOfWorldAnnual: CatalogPlan.SupporterPlus[Year.type],
-  guardianWeeklyDomesticAnnual: CatalogPlan.SupporterPlus[Year.type],
-  guardianWeeklyDomesticMonthly: CatalogPlan.SupporterPlus[Month.type],
 ) {
   lazy val plans = List(
     month,
     year,
-    guardianWeeklyRestOfWorldMonthly,
-    guardianWeeklyRestOfWorldAnnual,
-    guardianWeeklyDomesticAnnual,
-    guardianWeeklyDomesticMonthly
+  )
+}
+
+case class TierThreePlans(
+  domesticMonthy: CatalogPlan.TierThree[Month.type],
+  domesticAnnual: CatalogPlan.TierThree[Year.type],
+  restOfWorldMonthy: CatalogPlan.TierThree[Month.type],
+  restOfWorldAnnual: CatalogPlan.TierThree[Year.type],
+) {
+  lazy val plans = List(
+    domesticMonthy,
+    domesticAnnual,
+    restOfWorldMonthy,
+    restOfWorldAnnual,
   )
 }
 
@@ -331,6 +338,7 @@ case class WeeklyPlans(
 case class Catalog(
   digipack: DigipackPlans,
   supporterPlus: SupporterPlusPlans,
+  tierThree: TierThreePlans,
   contributor: CatalogPlan.Contributor,
   voucher: NonEmptyList[CatalogPlan.Voucher],
   digitalVoucher: NonEmptyList[CatalogPlan.DigitalVoucher],
@@ -345,8 +353,7 @@ case class Catalog(
   lazy val paid: Seq[CatalogPlan.Paid] = allSubs.flatten
 
   lazy val allSubs: List[List[CatalogPlan.Paid]] =
-    List(digipack.plans, supporterPlus.plans, voucher.list.toList, digitalVoucher.list.toList, delivery.list.toList, nationalDelivery.list.toList) ++ weekly.plans
-
+    List(digipack.plans, supporterPlus.plans, tierThree.plans, voucher.list.toList, digitalVoucher.list.toList, delivery.list.toList, nationalDelivery.list.toList) ++ weekly.plans
 }
 
 /**
@@ -414,6 +421,15 @@ case class SupporterPlusCharges(billingPeriod: BillingPeriod, pricingSummaries: 
   val subRatePlanChargeId = SubscriptionRatePlanChargeId("")
   override def price: PricingSummary = pricingSummaries.reduce(_ |+| _)
   override def benefits: NonEmptyList[Benefit] = NonEmptyList(SupporterPlus)
+}
+
+/** Tier Three
+  */
+case class TierThreeCharges(billingPeriod: BillingPeriod, pricingSummaries: List[PricingSummary]) extends PaidChargeList {
+
+  val subRatePlanChargeId = SubscriptionRatePlanChargeId("")
+  override def price: PricingSummary = pricingSummaries.reduce(_ |+| _)
+  override def benefits: NonEmptyList[Benefit] = NonEmptyList(TierThree)
 }
 
 /**
@@ -506,6 +522,7 @@ object SubscriptionPlan {
   type ContentSubscription = PaidSubscriptionPlan[Product.ContentSubscription, PaidChargeList]
   type Digipack = PaidSubscriptionPlan[Product.ZDigipack, PaidCharge[Benefit.Digipack.type, BillingPeriod]]
   type SupporterPlus = PaidSubscriptionPlan[Product.SupporterPlus, PaidCharge[Benefit.SupporterPlus.type, BillingPeriod]]
+  type TierThree = PaidSubscriptionPlan[Product.TierThree, PaidCharge[Benefit.TierThree.type, BillingPeriod]]
   type Delivery = PaidSubscriptionPlan[Product.Delivery, PaperCharges]
   type NationalDelivery = PaidSubscriptionPlan[Product.NationalDelivery, PaperCharges]
   type Voucher = PaidSubscriptionPlan[Product.Voucher, PaperCharges]

--- a/app/com/gu/memsub/subsv2/reads/CatPlanReads.scala
+++ b/app/com/gu/memsub/subsv2/reads/CatPlanReads.scala
@@ -43,6 +43,7 @@ object CatPlanReads {
   implicit val nD: CatPlanReads[NationalDelivery] = findProduct(_.nationalDelivery.point[List], NationalDelivery)
   implicit val y: CatPlanReads[Contribution] = findProduct(_.contributor.point[List], Contribution)
   implicit val s: CatPlanReads[SupporterPlus] = findProduct(_.supporterPlus.point[List], SupporterPlus)
+  implicit val t: CatPlanReads[TierThree] = findProduct(_.tierThree.point[List], TierThree)
   implicit val z: CatPlanReads[ZDigipack] = findProduct(_.digipack.point[List], Digipack)
 
   implicit val currentReads: CatPlanReads[Current] = new CatPlanReads[Current] {

--- a/app/com/gu/memsub/subsv2/services/CatalogService.scala
+++ b/app/com/gu/memsub/subsv2/services/CatalogService.scala
@@ -76,12 +76,14 @@ class CatalogService[M[_] : Monad](productIds: ProductIds, fetchCatalog: M[Strin
       ) (DigipackPlans)
     supporterPlus <- (
       one[SupporterPlus[Month.type]](plans, "Supporter Plus month", FrontendId.Monthly) |@|
-        one[SupporterPlus[Year.type]](plans, "Supporter Plus year", FrontendId.Yearly) |@|
-        one[SupporterPlus[Month.type]](plans, "Guardian Weekly Rest Of World Monthly", FrontendId.ThirdTierMonthlyROW) |@|
-        one[SupporterPlus[Year.type]](plans, "Guardian Weekly Rest Of World Annual", FrontendId.ThirdTierAnnualROW) |@|
-        one[SupporterPlus[Year.type]](plans, "Guardian Weekly Domestic Annual", FrontendId.ThirdTierAnnualDomestic) |@|
-        one[SupporterPlus[Month.type]](plans, "Guardian Weekly Domestic Monthly", FrontendId.ThirdTierMonthlyDomestic)
+        one[SupporterPlus[Year.type]](plans, "Supporter Plus year", FrontendId.Yearly)
       ) (SupporterPlusPlans)
+    tierThree <- (
+      one[TierThree[Month.type]](plans, "Supporter Plus & Guardian Weekly Domestic - Monthly", FrontendId.ThirdTierMonthlyDomestic) |@|
+        one[TierThree[Year.type]](plans, "Supporter Plus & Guardian Weekly ROW - Annual", FrontendId.ThirdTierAnnualDomestic) |@|
+        one[TierThree[Month.type]](plans, "Supporter Plus & Guardian Weekly ROW - Monthly", FrontendId.ThirdTierMonthlyROW) |@|
+        one[TierThree[Year.type]](plans, "Supporter Plus & Guardian Weekly Domestic - Annual", FrontendId.ThirdTierAnnualROW)
+      ) (TierThreePlans)
     contributor <- one[Contributor](plans, "Contributor month", FrontendId.Monthly)
     voucher <- many[Voucher](plans, "Paper voucher")
     digitalVoucher <- many[DigitalVoucher](plans, "Paper digital voucher")
@@ -122,7 +124,7 @@ class CatalogService[M[_] : Monad](productIds: ProductIds, fetchCatalog: M[Strin
     weekly = WeeklyPlans(weeklyZoneA, weeklyZoneB, weeklyZoneC, weeklyDomestic, weeklyRestOfWorld)
 
     map <- Validation.s[NonEmptyList[String]](plans.map(p => p.id -> p).toMap)
-  } yield Catalog(digipack, supporterPlus, contributor, voucher, digitalVoucher, delivery, nationalDelivery, weekly, map)
+  } yield Catalog(digipack, supporterPlus, tierThree, contributor, voucher, digitalVoucher, delivery, nationalDelivery, weekly, map)
 
 
   lazy val catalog: M[NonEmptyList[String] \/ Catalog] = (for {

--- a/app/controllers/RatePlanController.scala
+++ b/app/controllers/RatePlanController.scala
@@ -1,7 +1,7 @@
 package controllers
 
 import actions.GoogleAuthAction.GoogleAuthenticatedAction
-import com.gu.config.{DigitalPackRatePlanIds, SupporterPlusRatePlanIds}
+import com.gu.config.{DigitalPackRatePlanIds, SupporterPlusRatePlanIds, TierThreeRatePlanIds}
 import com.gu.i18n.Currency
 import com.gu.i18n.Currency.{AUD, CAD, EUR, GBP, USD}
 import com.gu.memsub.Price
@@ -15,6 +15,7 @@ import play.api.libs.json._
 import play.api.mvc.Results._
 
 import scala.concurrent.Future
+import com.gu.memsub.Benefit.TierThree
 
 case class RatePlan(ratePlanId: ProductRatePlanId, ratePlanName: String)
 
@@ -32,6 +33,7 @@ class RatePlanController(
     paperPlans: PaperProducts,
     digipackIds: DigitalPackRatePlanIds,
     supporterPlusIds: SupporterPlusRatePlanIds,
+    tierThreeIds: TierThreeRatePlanIds,
     weeklyPlans: WeeklyPlans,
     catalogService: CatalogService[Future],
 ) {
@@ -69,10 +71,12 @@ class RatePlanController(
       SupporterPlus.id -> Json.toJson(Seq(
           RatePlan(supporterPlusIds.yearly, "Annual"),
           RatePlan(supporterPlusIds.monthly, "Monthly"),
-          RatePlan(supporterPlusIds.guardianWeeklyRestOfWorldMonthly, "Guardian Weekly Rest Of World Monthly"),
-          RatePlan(supporterPlusIds.guardianWeeklyRestOfWorldAnnual, "Guardian Weekly Rest Of World Annual"),
-          RatePlan(supporterPlusIds.guardianWeeklyDomesticAnnual, "Guardian Weekly Domestic Annual"),
-          RatePlan(supporterPlusIds.guardianWeeklyDomesticMonthly, "Guardian Weekly Domestic Monthly"),
+      ).map(enhance)),
+      TierThree.id -> Json.toJson(Seq(
+          RatePlan(tierThreeIds.domesticAnnual, "Domestic Annual"),
+          RatePlan(tierThreeIds.domesticMonthly, "Domestic Monthly"),
+          RatePlan(tierThreeIds.restOfWorldMonthly, "RestOfWorld Monthly"),
+          RatePlan(tierThreeIds.restOfWorldAnnual, "RestOfWorld Annual"),
       ).map(enhance)),
       DigitalPack.id -> Json.toJson(Seq(
         RatePlan(digipackIds.digitalPackMonthly, "Digital Pack monthly"),

--- a/app/wiring/AppComponents.scala
+++ b/app/wiring/AppComponents.scala
@@ -1,5 +1,5 @@
 package wiring
-import com.gu.config.{DigitalPackRatePlanIds, SupporterPlusRatePlanIds}
+import com.gu.config.{DigitalPackRatePlanIds, SupporterPlusRatePlanIds, TierThreeRatePlanIds}
 import com.gu.googleauth.AuthAction
 import com.gu.memsub.auth.common.MemSub.Google.googleAuthConfigFor
 import com.gu.memsub.promo.{Campaign, DynamoTables}
@@ -39,6 +39,7 @@ class AppComponents(context: Context) extends BuiltInComponentsFromContext(conte
 
   lazy val digipackRatePlanIds = DigitalPackRatePlanIds.fromConfig(config.getConfig(AppComponents.ratePlanPath(stage) + ".digitalpack"))
   lazy val supporterPlusRatePlanIds = SupporterPlusRatePlanIds.fromConfig(config.getConfig(AppComponents.ratePlanPath(stage) + ".supporterPlus"))
+  lazy val tierThreeRatePlanIds = TierThreeRatePlanIds.fromConfig(config.getConfig(AppComponents.ratePlanPath(stage) + ".tierThree"))
   lazy val weeklyRatePlanIds = WeeklyPlans.fromConfig(config, stage)
 
   private val googleAuthConfig = googleAuthConfigFor(config, httpConfiguration)

--- a/conf/touchpoint.CODE.conf
+++ b/conf/touchpoint.CODE.conf
@@ -81,6 +81,7 @@ touchpoint.backend.environments {
                     nationalDelivery="8ad096ca8992481d018992a35483159d"
                     digipack="2c92c0f84b786da2014b91d3629b4298"
                     supporterPlus="8ad09fc281de1ce70181de3b23b2363d"
+                    tierThree="8ad097b48ff26452019001c67ad32035"
                 }
                 contributions={
                     contributor="2c92c0f85a6b134e015a7fcc183e756f"
@@ -105,10 +106,12 @@ touchpoint.backend.environments {
                 supporterPlus={
                     monthly="8ad08cbd8586721c01858804e3275376"
                     yearly="8ad08e1a8586721801858805663f6fab"
-                    guardianWeeklyRestOfWorldMonthly="8ad097b48f006681018f05a2c0fb0227"
-                    guardianWeeklyRestOfWorldAnnual="8ad097b48f006681018f05a0496e01f4"
-                    guardianWeeklyDomesticAnnual="8ad097b48f006681018f059b755e0140"
-                    guardianWeeklyDomesticMonthly="8ad081dd8ef57784018ef6e159224bfa"
+                }
+                tierThree={
+                    domesticMonthly="8ad097b48ff26452019001cebac92376"
+                    domesticAnnual="8ad081dd8ff24a9a019001d95e4e3574"
+                    restOfWorldMonthly="8ad081dd8ff24a9a019001df2ce83657"
+                    restOfWorldAnnual="8ad097b48ff26452019001e65bbf2ca8"
                 }
             }
             invoiceTemplateIds {

--- a/conf/touchpoint.PROD.conf
+++ b/conf/touchpoint.PROD.conf
@@ -66,6 +66,7 @@ touchpoint.backend.environments {
                     nationalDelivery="8a12999f8a268c57018a27ebddab1460"
                     digipack="2c92a0fb4edd70c8014edeaa4ddb21e7"
                     supporterPlus="8a12865b8219d9b4018221061563643f"
+                    tierThree="8a1295998ff2ec180190024b287b64c7"
                 }
                 contributions={
                     contributor="2c92a0fe5aacfabe015ad24bf6e15ff6"
@@ -94,6 +95,12 @@ touchpoint.backend.environments {
                     guardianWeeklyRestOfWorldAnnual="8a1292628f51a923018f52a324e45710"
                     guardianWeeklyDomesticAnnual="8a1282048f518d08018f529ead0f3d91"
                     guardianWeeklyDomesticMonthly="8a1288a38f518d01018f529a04443172"
+                }
+                tierThree={
+                    domesticMonthly="8a1299788ff2ec100190025fccc32bb1"
+                    domesticAnnual="8a1288a38ff2af980190025b32591ccc"
+                    restOfWorldMonthly="8a128ab18ff2af9301900255d77979ac"
+                    restOfWorldAnnual="8a1299788ff2ec100190024d1e3b1a09"
                 }
             }
             invoiceTemplateIds {

--- a/frontend/src/templates/EnvironmentMenu.html
+++ b/frontend/src/templates/EnvironmentMenu.html
@@ -10,6 +10,12 @@
             </md-button>
         </md-menu-item>
         <md-menu-item>
+            <md-button ng-click="ctrl.setCampaignGroup('tierThree')">
+                <md-icon md-font-set="material-icons" md-menu-align-target>emoji_events</md-icon>
+                Tier Three
+            </md-button>
+        </md-menu-item>
+        <md-menu-item>
             <md-button ng-click="ctrl.setCampaignGroup('digitalpack')">
                 <md-icon md-font-set="material-icons" md-menu-align-target>tablet_mac</md-icon>
                 Digital Pack


### PR DESCRIPTION
This PR
- Introduces the new `TierThree` product
- Removes the now obsolete `ratePlans` from `SupporterPlus` that were going to fulfil this functionality

It's a relatively large PR, but I think that's just the nature of adding things to the promo tool.