### PR TITLE
fix: remove tier three rateplans from supporterplus

### DIFF
--- a/conf/touchpoint.PROD.conf
+++ b/conf/touchpoint.PROD.conf
@@ -90,11 +90,7 @@ touchpoint.backend.environments {
                 }
                 supporterPlus={
                     monthly="8a128ed885fc6ded018602296ace3eb8"
-                    yearly="8a128ed885fc6ded01860228f77e3d5a"
-                    guardianWeeklyRestOfWorldMonthly="8a1281f38f518d11018f52a599806a65"
-                    guardianWeeklyRestOfWorldAnnual="8a1292628f51a923018f52a324e45710"
-                    guardianWeeklyDomesticAnnual="8a1282048f518d08018f529ead0f3d91"
-                    guardianWeeklyDomesticMonthly="8a1288a38f518d01018f529a04443172"
+                    yearly="8a128ed885fc6ded01860228f77e3d5a"   
                 }
                 tierThree={
                     domesticMonthly="8a1299788ff2ec100190025fccc32bb1"


### PR DESCRIPTION
These `ratePlans` are no longer used and we should be using the `tierThree` product instead