### PR TITLE
Override jackson-core

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -50,7 +50,6 @@ javaOptions in Universal ++= Seq(
 scalaVersion := "2.13.10"
 scalacOptions ++= Seq("-feature")
 
-val jacksonVersion = "2.13.3"
 val awsVersion = "1.12.649"
 
 libraryDependencies ++= Seq(
@@ -61,9 +60,6 @@ libraryDependencies ++= Seq(
   "com.softwaremill.macwire" %% "macros" % "2.5.0" % "provided",
   "com.softwaremill.macwire" %% "util" % "2.5.0",
   "com.softwaremill.macwire" %% "proxy" % "2.5.0",
-  // Use the latest version of jackson
-  "com.fasterxml.jackson.core" % "jackson-databind" % jacksonVersion,
-  "com.fasterxml.jackson.module" %% "jackson-module-scala" % jacksonVersion,
   "com.amazonaws" % "aws-java-sdk-s3" % awsVersion,
   "com.amazonaws" % "aws-java-sdk-dynamodb" % awsVersion,
   "org.scalaz" %% "scalaz-core" % "7.3.7",
@@ -73,6 +69,11 @@ libraryDependencies ++= Seq(
   "com.squareup.okhttp3" % "okhttp" % "4.10.0",
   "com.typesafe.play" %% "play-json-joda" % "2.10.4",
   "org.scalatestplus.play" %% "scalatestplus-play" % "7.0.1" % Test
+)
+
+dependencyOverrides ++= List(
+  // Play still uses an old version of jackson-core which has a vulnerability - https://security.snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-7569538
+  "com.fasterxml.jackson.core" % "jackson-core" % "2.17.2"
 )
 
 resolvers ++= Seq(


### PR DESCRIPTION
Snyk has flagged the current version of jackson-core as a high vulnerability - https://security.snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-7569538
This comes via Play:
![Screenshot 2024-08-09 at 10 17 12](https://github.com/user-attachments/assets/13ab3eea-e7ae-4649-b3c9-c2888d832e67)



Although there are newer versions of jackson without that vulnerability, the latest version of Play still uses the old version of jackson. (There is [a PR](https://github.com/playframework/playframework/pull/12440) but things move slowly.)
So for now we have to override the jackson-core version, until Play is updated.

Tested in CODE