### PR TITLE
feat: remove hard-coded invoice template IDs

### DIFF
--- a/conf/touchpoint.CODE.conf
+++ b/conf/touchpoint.CODE.conf
@@ -114,10 +114,6 @@ touchpoint.backend.environments {
                     restOfWorldAnnual="8ad097b48ff26452019001e65bbf2ca8"
                 }
             }
-            invoiceTemplateIds {
-              GB="2c92c0f849369b8801493bf7db7e450e"
-              AU="2c92c0f85ecc47e5015ee7360d602757"
-            }
         }
     }
 }

--- a/conf/touchpoint.PROD.conf
+++ b/conf/touchpoint.PROD.conf
@@ -99,10 +99,6 @@ touchpoint.backend.environments {
                     restOfWorldAnnual="8a1299788ff2ec100190024d1e3b1a09"
                 }
             }
-            invoiceTemplateIds {
-              GB="2c92a0fb49377eae014951ca848e074b"
-              AU="2c92a0fd5ecce80c015ee71028643020"
-            }
         }
     }
 }


### PR DESCRIPTION
## What does this change?

[Trello](https://trello.com/c/h7MX4D5w/260-remove-all-references-to-hard-coded-invoice-template-ids-and-move-all-customers-to-new-invoice-template)

This removes all references to hard-coded invoice template IDs.

## Why are you doing this?

We have recently created a [generic HTML template](https://github.com/guardian/zuora-config/blob/main/finance/invoice-templates/system-default.html) that will be used by default for all products / accounts.
