### PR TITLE
Enable builds for dependabot branches

### DIFF
--- a/.github/workflows/memsub-promotions.yml
+++ b/.github/workflows/memsub-promotions.yml
@@ -11,9 +11,8 @@ on:
 jobs:
   memsub-promotions:
     if: >-
-      (github.actor != 'dependabot[bot]') &&
-        (github.event.pull_request.head.repo.owner.login == 'guardian' ||
-          github.event_name == 'push')
+      (github.event.pull_request.head.repo.owner.login == 'guardian' ||
+        github.event_name == 'push')
     # Required by actions-assume-aws-role
     permissions:
       id-token: write


### PR DESCRIPTION
currently it prevents us from testing dependabot PRs