### PR TITLE
Small tweak to the description field label wording

### DIFF
--- a/frontend/src/templates/PromotionForm.html
+++ b/frontend/src/templates/PromotionForm.html
@@ -13,7 +13,7 @@
                     </div>
                 </md-input-container>
                 <md-input-container class="md-block">
-                    <label>Description for checkout page summary and showcase page promotional copy</label>
+                    <label>Description for landing page promotional copy</label>
                     <input ng-model="promotion.description" name="description" required/>
                     <div ng-messages="promotionForm.description.$error" role="alert">
                         <ng-message when="required">Please enter a description</ng-message>


### PR DESCRIPTION
## What does this change?

This changes the wording of the description form field label in the tool UI, to make it clearer how this field is used.

## How to test

Tested on CODE (I had issues trying to run this tool locally).

## Images

Before:

<img width="462" height="91" alt="Screenshot 2025-07-30 at 17 34 17" src="https://github.com/user-attachments/assets/e1b57c07-b05b-4f9a-a9fa-b1c38831445f" />

After:

<img width="289" height="73" alt="Screenshot 2025-07-30 at 17 40 14" src="https://github.com/user-attachments/assets/82d06138-4300-4551-b506-4912aa39dbda" />